### PR TITLE
Add GitHub Container Registry Docker publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,65 @@
+name: Docker Image Publishing
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual trigger for testing
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for versioning
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ Use `--log-level` (e.g., `--log-level DEBUG`) and `--log-to-console` to control 
 
 ### Run with Docker
 
+#### Option 1: Pull from GitHub Container Registry (Recommended)
+
+Pull and run the pre-built image:
+
+```bash
+docker pull ghcr.io/avivsinai/langfuse-mcp:latest
+docker run --rm -i \
+  -e LANGFUSE_PUBLIC_KEY=YOUR_PUBLIC_KEY \
+  -e LANGFUSE_SECRET_KEY=YOUR_SECRET_KEY \
+  -e LANGFUSE_HOST=https://cloud.langfuse.com \
+  -e LANGFUSE_MCP_LOG_FILE=/logs/langfuse_mcp.log \
+  -v "$(pwd)/logs:/logs" \
+  ghcr.io/avivsinai/langfuse-mcp:latest
+```
+
+Available tags:
+- `latest` - Most recent release
+- `v0.2.0` - Specific version
+- `0.2` - Major.minor version
+
+#### Option 2: Build from source
+
 Build the image from the repository root so the container installs the current checkout instead of the latest PyPI release:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds automated Docker image publishing to GitHub Container Registry (ghcr.io) on releases
- Implements 2025 Docker security best practices with SLSA attestations and SBOM
- Updates README with instructions for pulling pre-built images

## Changes
### Workflow (`.github/workflows/docker-publish.yml`)
- Triggers on release publication and manual workflow dispatch
- Builds and pushes to `ghcr.io/avivsinai/langfuse-mcp`
- Implements security features:
  - Docker Buildx for multi-platform support
  - SLSA provenance attestations (`mode=max`)
  - Software Bill of Materials (SBOM)
  - Cryptographic artifact attestation for supply chain security
- Automated semantic versioning tags: `latest`, `v0.2.0`, `0.2`, `0`

### Documentation (`README.md`)
- Added "Option 1: Pull from GitHub Container Registry (Recommended)"
- Provides pull and run commands for pre-built images
- Lists available image tags
- Keeps existing build-from-source instructions as Option 2

## Benefits
- Colleagues can pull images directly: `docker pull ghcr.io/avivsinai/langfuse-mcp:latest`
- No manual Docker builds required for end users
- Images include verifiable provenance for enterprise security
- Meets SLSA Build Level 2 requirements
- Free hosting on GitHub Container Registry

## Testing Plan
- [x] Verified Dockerfile syntax
- [ ] Merge PR to main
- [ ] Create a new release (or manually trigger workflow)
- [ ] Verify image published to ghcr.io
- [ ] Test pulling and running the published image

## Related Issue
Addresses request from colleague to publish Docker images to a registry for MCP gateway integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)