### PR TITLE
docs: add datasets playbook and fix doc/code mismatches

### DIFF
--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Debug your AI systems through Langfuse observability.
 
-**Triggers:** langfuse, traces, debug AI, find exceptions, set up langfuse, what went wrong, why is it slow
+**Triggers:** langfuse, traces, debug AI, find exceptions, set up langfuse, what went wrong, why is it slow, datasets, evaluation sets
 
 ## Setup
 
@@ -133,6 +133,39 @@ get_session_details(session_id="...")
 
 ---
 
+### "Manage datasets"
+
+```
+list_datasets()
+```
+→ See all datasets.
+
+```
+get_dataset(name="evaluation-set-v1")
+```
+→ Get dataset details.
+
+```
+list_dataset_items(dataset_name="evaluation-set-v1", page=1, limit=10)
+```
+→ Browse items in the dataset.
+
+```
+create_dataset(name="qa-test-cases", description="QA evaluation set")
+```
+→ Create a new dataset.
+
+```
+create_dataset_item(
+  dataset_name="qa-test-cases",
+  input={"question": "What is 2+2?"},
+  expected_output={"answer": "4"}
+)
+```
+→ Add test cases.
+
+---
+
 ### "Manage prompts"
 
 ```
@@ -171,6 +204,9 @@ update_prompt_labels(name="...", version=N, labels=["production"])
 | User sessions | `get_user_sessions(user_id="...", age=N)` |
 | List prompts | `list_prompts()` |
 | Get prompt | `get_prompt(name="...", label="production")` |
+| List datasets | `list_datasets()` |
+| Get dataset | `get_dataset(name="...")` |
+| List dataset items | `list_dataset_items(dataset_name="...", limit=N)` |
 
 `age` = minutes to look back (max 10080 = 7 days)
 

--- a/skills/langfuse/references/tool-reference.md
+++ b/skills/langfuse/references/tool-reference.md
@@ -18,7 +18,7 @@ Complete documentation for all 25 Langfuse MCP tools.
 
 ## Output Modes
 
-Most tools support three output modes via the `output_mode` parameter:
+Some tools support output modes via the `output_mode` parameter:
 
 | Mode | Description |
 |------|-------------|
@@ -26,43 +26,36 @@ Most tools support three output modes via the `output_mode` parameter:
 | `full_json_string` | Complete data as JSON string (returns string, not object) |
 | `full_json_file` | Save to file, return summary with path |
 
-**Exceptions:** `find_exceptions` and `get_error_count` do not support `output_mode` (always return compact format).
+**Tools with output_mode:** `fetch_traces`, `fetch_trace`, `fetch_observations`, `fetch_observation`, `fetch_sessions`, `get_session_details`, `get_user_sessions`, `find_exceptions_in_file`, `get_exception_details`, `list_dataset_items`, `get_dataset_item`
+
+**Tools without output_mode:** `find_exceptions`, `get_error_count`, `list_prompts`, `get_prompt`, `get_prompt_unresolved`, `create_text_prompt`, `create_chat_prompt`, `update_prompt_labels`, `list_datasets`, `get_dataset`, `create_dataset`, `create_dataset_item`, `delete_dataset_item`, `get_data_schema`
 
 ## Filter Semantics
 
+Filter behavior depends on the Langfuse API:
+
 | Filter | Matching Rule |
 |--------|---------------|
-| `name` | Case-insensitive substring match |
-| `tags` | Comma-separated, matches ANY tag (OR logic) |
+| `name` | Passed to Langfuse API (behavior varies by endpoint) |
+| `tags` | Comma-separated, passed to Langfuse API |
 | `metadata` | Exact key/value match, top-level keys only |
 | `user_id`, `session_id`, `trace_id` | Exact match |
 
+**Note:** `list_prompts` uses exact name matching. Other tools pass filters to the Langfuse API.
+
 ## Sort Order
 
-All paginated results are sorted by **timestamp descending** (newest first).
+Sort order depends on the Langfuse API. Traces and observations are typically sorted by timestamp descending (newest first).
 
 ## Pagination
 
-Tools that return lists support pagination via `page` and `limit` parameters:
+Some tools support pagination via `page` and `limit` parameters. Check individual tool docs.
 
-- `page`: Page number (starts at 1)
-- `limit`: Items per page (default 50, max varies by tool)
+**Tools with pagination:** `fetch_traces`, `fetch_observations`, `fetch_sessions`, `list_prompts`, `list_datasets`, `list_dataset_items`
 
-**Response metadata includes:**
-```json
-{
-  "metadata": {
-    "page": 1,
-    "total": 147,
-    "next_page": 2,
-    "item_count": 50
-  }
-}
-```
+**Tools without pagination:** `find_exceptions`, `find_exceptions_in_file`, `get_exception_details`, `get_user_sessions`
 
-**Pattern:** If `next_page` exists, call again with `page=next_page` to get more results.
-
-**Tip:** For large datasets, use `output_mode="full_json_file"` to avoid context overflow.
+**Tip:** For large results, use `output_mode="full_json_file"` to avoid context overflow.
 
 ---
 
@@ -76,11 +69,11 @@ Search and filter traces with pagination.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `age` | int | Yes | - | Look back window in minutes from now (e.g., 1440 for 24h). Max 10080 (7 days). |
-| `name` | string | No | null | Name filter (case-insensitive substring match) |
+| `name` | string | No | null | Name filter (passed to API) |
 | `user_id` | string | No | null | User ID to filter traces by (exact match) |
 | `session_id` | string | No | null | Session ID to filter traces by (exact match) |
 | `metadata` | object | No | null | Metadata fields to filter by (exact key/value match) |
-| `tags` | string | No | null | Tag or comma-separated list of tags (matches any) |
+| `tags` | string | No | null | Tag or comma-separated list of tags |
 | `page` | int | No | 1 | Page number for pagination (starts at 1) |
 | `limit` | int | No | 50 | Maximum traces per page |
 | `include_observations` | bool | No | false | Include full observation objects instead of just IDs |
@@ -126,7 +119,7 @@ Search and filter observations (spans, generations, events).
 |------|------|----------|---------|-------------|
 | `age` | int | Yes | - | Look back window in minutes from now. Max 10080 (7 days). |
 | `type` | string | No | null | Filter by type: "SPAN", "GENERATION", or "EVENT" |
-| `name` | string | No | null | Name filter (case-insensitive substring match) |
+| `name` | string | No | null | Name filter (passed to API) |
 | `user_id` | string | No | null | User ID filter (exact match) |
 | `trace_id` | string | No | null | Trace ID filter (exact match) |
 | `parent_observation_id` | string | No | null | Parent observation ID filter (exact match) |
@@ -183,6 +176,7 @@ Get detailed session info by ID.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `session_id` | string | Yes | - | The session ID to fetch |
+| `include_observations` | bool | No | false | Include full observation objects instead of just IDs |
 | `output_mode` | string | No | "compact" | Output format |
 
 **Returns:** Session object with all traces.
@@ -198,8 +192,7 @@ Get all sessions for a user.
 |------|------|----------|---------|-------------|
 | `user_id` | string | Yes | - | The user ID to look up |
 | `age` | int | Yes | - | Look back window in minutes from now. Max 10080 (7 days). |
-| `page` | int | No | 1 | Page number |
-| `limit` | int | No | 50 | Max items per page |
+| `include_observations` | bool | No | false | Include full observation objects instead of just IDs |
 | `output_mode` | string | No | "compact" | Output format |
 
 **Returns:** List of sessions for the user.
@@ -276,7 +269,20 @@ Get total error count.
 |------|------|----------|---------|-------------|
 | `age` | int | Yes | - | Look back window in minutes from now. Max 10080 (7 days). |
 
-**Returns:** `{data: {error_count: int}, metadata: {...}}`
+**Returns:**
+```json
+{
+  "data": {
+    "age_minutes": 60,
+    "from_timestamp": "2024-01-15T09:30:00Z",
+    "to_timestamp": "2024-01-15T10:30:00Z",
+    "trace_count": 5,
+    "observation_count": 12,
+    "exception_count": 18
+  },
+  "metadata": {...}
+}
+```
 
 **Note:** Does not support `output_mode` parameter.
 
@@ -331,11 +337,11 @@ get_prompt(name="chat-system", label="production")
 
 Fetch a prompt WITHOUT resolving dependencies.
 
-Returns raw prompt content with dependency tags intact (e.g., `@@@langfusePrompt:name=xxx@@@`).
+Returns raw prompt content with dependency tags intact (e.g., `@@@langfusePrompt:name=xxx@@@`) when the SDK supports `resolve=false`. If the SDK doesn't support this parameter, returns the resolved prompt and sets `metadata.resolved=true` to indicate fallback behavior.
 
 **Parameters:** Same as `get_prompt`.
 
-**Returns:** Same structure but with dependency tags preserved in prompt content.
+**Returns:** Same structure but with dependency tags preserved in prompt content. Check `metadata.resolved` to verify if unresolved content was returned.
 
 ---
 
@@ -474,13 +480,13 @@ Get a dataset by name.
 **Parameters:**
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dataset_name` | string | Yes | - | The name of the dataset to fetch |
+| `name` | string | Yes | - | The name of the dataset to fetch |
 
 **Returns:** Dataset object with full details.
 
 **Example:**
 ```
-get_dataset(dataset_name="evaluation-set-v1")
+get_dataset(name="evaluation-set-v1")
 ```
 
 ---
@@ -497,6 +503,7 @@ List items in a dataset with optional filters.
 | `source_observation_id` | string | No | null | Filter by source observation ID |
 | `page` | int | No | 1 | Page number |
 | `limit` | int | No | 50 | Max items per page |
+| `output_mode` | string | No | "compact" | Output format |
 
 **Returns:** List of dataset items.
 
@@ -514,13 +521,14 @@ Get a specific dataset item by ID.
 **Parameters:**
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dataset_item_id` | string | Yes | - | The ID of the dataset item to fetch |
+| `item_id` | string | Yes | - | The ID of the dataset item to fetch |
+| `output_mode` | string | No | "compact" | Output format |
 
 **Returns:** Dataset item object with full details.
 
 **Example:**
 ```
-get_dataset_item(dataset_item_id="item-abc-123")
+get_dataset_item(item_id="item-abc-123")
 ```
 
 ---
@@ -553,12 +561,12 @@ Create or upsert a dataset item.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `dataset_name` | string | Yes | - | The name of the dataset |
-| `input` | any | Yes | - | Input data for the item |
+| `input` | any | No | null | Input data for the item |
 | `expected_output` | any | No | null | Expected output for evaluation |
 | `metadata` | object | No | null | Additional metadata |
 | `source_trace_id` | string | No | null | Link to source trace |
 | `source_observation_id` | string | No | null | Link to source observation |
-| `id` | string | No | null | Item ID (for upsert; if exists, updates the item) |
+| `item_id` | string | No | null | Item ID (for upsert; if exists, updates the item) |
 | `status` | string | No | null | Item status (e.g., "ACTIVE", "ARCHIVED") |
 
 **Returns:** Created or updated dataset item object.
@@ -582,13 +590,13 @@ Delete a dataset item.
 **Parameters:**
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dataset_item_id` | string | Yes | - | The ID of the dataset item to delete |
+| `item_id` | string | Yes | - | The ID of the dataset item to delete |
 
 **Returns:** Confirmation of deletion.
 
 **Example:**
 ```
-delete_dataset_item(dataset_item_id="item-abc-123")
+delete_dataset_item(item_id="item-abc-123")
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Add datasets playbook and quick reference to SKILL.md
- Fix 11 documentation/code mismatches found during review

## Changes

**SKILL.md:**
- Add "Manage datasets" playbook with examples
- Add datasets to Quick Reference table
- Add "datasets, evaluation sets" to triggers

**tool-reference.md:**
- Fix parameter names to match code (`name`, `item_id`)
- Rewrite Output Modes section with accurate tool lists
- Clarify filter semantics as API-dependent
- Fix `get_session_details`/`get_user_sessions` params
- Add `output_mode` to `list_dataset_items`/`get_dataset_item`
- Fix `create_dataset_item` input as optional
- Fix `get_error_count` return shape
- Add `get_prompt_unresolved` fallback behavior note

## Test plan

- [x] All 36 tests pass
- [x] Reviewed by Codex (thorough doc/code comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)