### PR TITLE
fix(ci): consolidate publishing into release workflow, harden all actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,16 @@
 name: Docker Image Publishing
 
 on:
-  push:
-    tags:
-      - "v*"
-  workflow_dispatch:  # Allow manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.6.5)"
+        required: true
+        type: string
+
+concurrency:
+  group: docker-publish-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -14,6 +20,7 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -22,21 +29,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0  # Required for versioning
+          fetch-depth: 0
+          ref: refs/tags/${{ inputs.tag }}
 
       - name: Verify release metadata
-        run: ./scripts/check-release-version.sh "${GITHUB_REF_NAME}"
+        run: ./scripts/check-release-version.sh "${{ inputs.tag }}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -44,18 +52,17 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}},value=${{ inputs.tag }}
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -66,7 +73,7 @@ jobs:
           sbom: true
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,6 +12,10 @@ permissions:
   security-events: write
   actions: read
 
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Scan for secrets
@@ -19,13 +23,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
         id: gitleaks
-        uses: DariuszPorowski/github-action-gitleaks@v2
+        uses: DariuszPorowski/github-action-gitleaks@a027585cb1f2780aa441f20f4d0aabf8b1a0d90e # v2
         with:
           config: .gitleaks.toml
           report_format: sarif
@@ -34,7 +38,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: steps.gitleaks.outputs.exitcode == 1
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           sarif_file: ${{ steps.gitleaks.outputs.report }}
 

--- a/.github/workflows/notify-marketplace.yml
+++ b/.github/workflows/notify-marketplace.yml
@@ -3,10 +3,15 @@ name: Notify Skills Marketplace
 on:
   push:
 
+concurrency:
+  group: notify-marketplace-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   notify:
     if: github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -1,23 +1,30 @@
 name: Publish Skills
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (e.g. 0.5.4)'
+      tag:
+        description: 'Tag to publish (e.g. v0.6.5)'
         required: true
         type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: skill-publish-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: refs/tags/${{ inputs.tag }}
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -30,15 +37,12 @@ jobs:
           echo '${{ secrets.SKILD_AUTH_JSON }}' > ~/.skild/registry-auth.json
 
       - name: Verify release metadata
-        run: ./scripts/check-release-version.sh "${{ inputs.version || github.ref_name }}"
+        run: ./scripts/check-release-version.sh "${{ inputs.tag }}"
 
       - name: Publish skills
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            TAG_VERSION="${{ inputs.version }}"
-          else
-            TAG_VERSION="${GITHUB_REF_NAME#v}"
-          fi
+          TAG_VERSION="${{ inputs.tag }}"
+          TAG_VERSION="${TAG_VERSION#v}"
 
           echo "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' || {
             echo "ERROR: version '$TAG_VERSION' is not semver"
@@ -58,7 +62,7 @@ jobs:
             if [ ${#SKILL} -ge 3 ] && [ ${#SKILL} -le 64 ]; then
               ALIAS_ARGS=(--alias "$SKILL")
             else
-              echo "⚠ Skipping alias for $SKILL: length ${#SKILL} outside 3..64"
+              echo "Warning: Skipping alias for $SKILL: length ${#SKILL} outside 3..64"
             fi
 
             if OUTPUT=$(npx skild publish \
@@ -66,28 +70,28 @@ jobs:
               "${ALIAS_ARGS[@]}" \
               --skill-version "$VERSION" 2>&1); then
               echo "$OUTPUT"
-              echo "✓ Published $SKILL version $VERSION"
+              echo "Published $SKILL version $VERSION"
             elif echo "$OUTPUT" | grep -q "Version already exists"; then
               echo "$OUTPUT"
-              echo "⚠ $SKILL version $VERSION already published — skipping"
+              echo "Warning: $SKILL version $VERSION already published — skipping"
             elif echo "$OUTPUT" | grep -q "Alias already in use"; then
               echo "$OUTPUT"
-              echo "⚠ Alias '$SKILL' taken — retrying without alias..."
+              echo "Warning: Alias '$SKILL' taken — retrying without alias..."
               if OUTPUT2=$(npx skild publish \
                 --dir "$dir" \
                 --skill-version "$VERSION" 2>&1); then
                 echo "$OUTPUT2"
-                echo "✓ Published $SKILL version $VERSION (without alias)"
+                echo "Published $SKILL version $VERSION (without alias)"
               elif echo "$OUTPUT2" | grep -q "Version already exists"; then
                 echo "$OUTPUT2"
-                echo "⚠ $SKILL version $VERSION already published on retry — skipping"
+                echo "Warning: $SKILL version $VERSION already published on retry — skipping"
               else
-                echo "✖ Publish failed for $SKILL (even without alias)"
+                echo "ERROR: Publish failed for $SKILL (even without alias)"
                 echo "$OUTPUT2"
                 FAILED=1
               fi
             else
-              echo "✖ Publish failed for $SKILL"
+              echo "ERROR: Publish failed for $SKILL"
               echo "$OUTPUT"
               FAILED=1
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,46 @@
 name: Publishing
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.6.5)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-publish-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
-        fetch-depth: 0  # Required for uv-dynamic-versioning to access git tags
+        fetch-depth: 0
+        ref: refs/tags/${{ inputs.tag }}
+
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
 
     - name: Verify release metadata
-      run: ./scripts/check-release-version.sh "${GITHUB_REF_NAME}"
+      run: ./scripts/check-release-version.sh "${{ inputs.tag }}"
 
     - name: Build
-      run: uv build
+      run: uv build --python 3.12
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: release-dists
         path: dist/
@@ -33,15 +49,16 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [build]
     steps:
     - name: Retrieve release distributions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: release-dists
         path: dist/
 
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ on:
         description: "Which artifacts to publish (push always publishes all)"
         required: false
         type: choice
-        default: all
+        default: github-release-only
         options:
-          - all
           - github-release-only
+          - all
           - docker-only
           - pypi-only
           - skills-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
   cancel-in-progress: false
@@ -23,6 +20,8 @@ jobs:
     if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release): v') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       version: ${{ steps.prepare.outputs.version }}
@@ -30,7 +29,7 @@ jobs:
       release_sha: ${{ steps.prepare.outputs.release_sha }}
       prerelease: ${{ steps.prepare.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -114,17 +113,19 @@ jobs:
     if: needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
 
       - name: Create local release tag for dynamic versioning
         shell: bash
@@ -157,17 +158,19 @@ jobs:
     if: needs.prepare.result == 'success' && needs.verify.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
 
       - name: Create release tag after verification
         shell: bash
@@ -219,7 +222,7 @@ jobs:
           PY
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           target_commitish: ${{ needs.prepare.outputs.release_sha }}
@@ -229,3 +232,185 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+
+      - name: Upload build artifacts for downstream jobs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-dists
+          path: dist/
+          retention-days: 1
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: [prepare, release]
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  docker-publish:
+    name: Publish Docker image
+    needs: [prepare, release]
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - name: Create local tag for versioning
+        shell: bash
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git tag "${TAG}" "${RELEASE_SHA}"
+          fi
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.prepare.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ needs.prepare.outputs.tag }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.prerelease == 'false' && github.event_name == 'push' }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  skill-publish:
+    name: Publish skills
+    needs: [prepare, release]
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Install skild
+        run: npm install -g skild
+
+      - name: Configure skild auth
+        run: |
+          mkdir -p ~/.skild
+          echo '${{ secrets.SKILD_AUTH_JSON }}' > ~/.skild/registry-auth.json
+
+      - name: Verify release metadata
+        run: ./scripts/check-release-version.sh "${{ needs.prepare.outputs.version }}"
+
+      - name: Publish skills
+        run: |
+          TAG_VERSION="${{ needs.prepare.outputs.version }}"
+
+          FAILED=0
+
+          for dir in skills/*/; do
+            [ -f "$dir/SKILL.md" ] || continue
+            SKILL=$(basename "$dir")
+            VERSION="${TAG_VERSION}"
+
+            echo "Publishing $SKILL version $VERSION"
+
+            ALIAS_ARGS=()
+            if [ ${#SKILL} -ge 3 ] && [ ${#SKILL} -le 64 ]; then
+              ALIAS_ARGS=(--alias "$SKILL")
+            else
+              echo "Warning: Skipping alias for $SKILL: length ${#SKILL} outside 3..64"
+            fi
+
+            if OUTPUT=$(npx skild publish \
+              --dir "$dir" \
+              "${ALIAS_ARGS[@]}" \
+              --skill-version "$VERSION" 2>&1); then
+              echo "$OUTPUT"
+              echo "Published $SKILL version $VERSION"
+            elif echo "$OUTPUT" | grep -q "Version already exists"; then
+              echo "$OUTPUT"
+              echo "Warning: $SKILL version $VERSION already published — skipping"
+            elif echo "$OUTPUT" | grep -q "Alias already in use"; then
+              echo "$OUTPUT"
+              echo "Warning: Alias '$SKILL' taken — retrying without alias..."
+              if OUTPUT2=$(npx skild publish \
+                --dir "$dir" \
+                --skill-version "$VERSION" 2>&1); then
+                echo "$OUTPUT2"
+                echo "Published $SKILL version $VERSION (without alias)"
+              elif echo "$OUTPUT2" | grep -q "Version already exists"; then
+                echo "$OUTPUT2"
+                echo "Warning: $SKILL version $VERSION already published on retry — skipping"
+              else
+                echo "ERROR: Publish failed for $SKILL (even without alias)"
+                echo "$OUTPUT2"
+                FAILED=1
+              fi
+            else
+              echo "ERROR: Publish failed for $SKILL"
+              echo "$OUTPUT"
+              FAILED=1
+            fi
+          done
+
+          exit $FAILED

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,17 @@ on:
         description: "Existing tag to (re)release (e.g. v0.6.2)"
         required: true
         type: string
+      publish:
+        description: "Which artifacts to publish (push always publishes all)"
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - github-release-only
+          - docker-only
+          - pypi-only
+          - skills-only
 
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
@@ -243,7 +254,9 @@ jobs:
   pypi-publish:
     name: Publish to PyPI
     needs: [prepare, release]
-    if: needs.release.result == 'success'
+    if: >-
+      needs.release.result == 'success' &&
+      (github.event_name == 'push' || inputs.publish == 'all' || inputs.publish == 'pypi-only')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -263,7 +276,9 @@ jobs:
   docker-publish:
     name: Publish Docker image
     needs: [prepare, release]
-    if: needs.release.result == 'success'
+    if: >-
+      needs.release.result == 'success' &&
+      (github.event_name == 'push' || inputs.publish == 'all' || inputs.publish == 'docker-only')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -336,7 +351,9 @@ jobs:
   skill-publish:
     name: Publish skills
     needs: [prepare, release]
-    if: needs.release.result == 'success'
+    if: >-
+      needs.release.result == 'success' &&
+      (github.event_name == 'push' || inputs.publish == 'all' || inputs.publish == 'skills-only')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,22 +6,30 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Check skill sync
       run: make check-skills
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
 
     - name: Install dependencies
       run: |
@@ -43,11 +51,12 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
 
     - name: Install dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Consolidated PyPI, Docker, and skill publishing into the release workflow so they no longer depend on tag-push events that `GITHUB_TOKEN` cannot trigger.
+- Pinned all GitHub Actions to commit SHAs across every workflow for supply-chain safety.
+- Added missing `permissions`, `timeout-minutes`, and `concurrency` blocks to all workflows.
+- Standalone publish workflows now accept `workflow_dispatch` with an explicit `tag` input and check out the tag ref, making manual reruns safe regardless of branch context.
+
 ## [0.6.5] - 2026-04-02
 ### Changed
 - Switched releases to the shared PR-based `scripts/release.sh` flow, with `CHANGELOG.md` supplying the GitHub release notes and CI creating the version tag only after the merged release commit verifies.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -256,8 +256,7 @@ pr_body=$(
 
 - moves \`CHANGELOG.md\` into \`${tag}\`
 - aligns skill/plugin metadata to \`${version}\`
-- merge triggers \`.github/workflows/release.yml\`, which validates the release commit, creates \`${tag}\`, and publishes the GitHub release
-- PyPI, Docker, and skill publishing continue to run from the CI-created tag
+- merge triggers \`.github/workflows/release.yml\`, which validates the release commit, creates \`${tag}\`, publishes the GitHub release, then publishes to PyPI, Docker (GHCR), and the skills marketplace in the same workflow run
 EOF
 )
 


### PR DESCRIPTION
## Summary

- **Critical fix**: `GITHUB_TOKEN` tag pushes from `release.yml` do not trigger downstream workflows, so v0.6.5 never published to PyPI, Docker, or the skills marketplace
- **Fix**: Added `pypi-publish`, `docker-publish`, and `skill-publish` jobs directly into `release.yml`, gated on the `release` job succeeding
- Standalone publish workflows (`publish.yml`, `docker-publish.yml`, `publish-skill.yml`) retain `workflow_dispatch` only — for manual reruns with explicit `tag` input
- Pinned all GitHub Actions to commit SHAs across all 7 workflows
- Added missing `permissions`, `timeout-minutes`, and `concurrency` blocks to all workflows
- Guarded Docker `latest` tag against prereleases and manual reruns
- Pinned standalone `publish.yml` to Python 3.12 to match the hardened release path

### New release.yml job chain
```
prepare → verify → release (tag + GH release) → pypi-publish ┐
                                                 docker-publish ├ (parallel)
                                                 skill-publish  ┘
```

## Codex Review

Design reviewed and approved by Codex. Two findings (latest tag guard, Python pinning in publish.yml) were fixed before commit.

## Test plan

- [ ] CI passes on this PR (test + gitleaks)
- [ ] After merge, trigger `workflow_dispatch` on `release.yml` with tag `v0.6.5` to publish the missing artifacts
- [ ] Verify v0.6.5 appears on PyPI, GHCR, and skills marketplace
- [ ] Next release via `release.sh` should publish all artifacts in one workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)