### PR TITLE
fix(deps): add 7-day cooldown to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,12 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
     rebase-strategy: "disabled" # use dependabot-rebase-stale
     commit-message:
       prefix: chore
       prefix-development: chore
-      include: scope 
+      include: scope
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ combine-as-imports = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"


### PR DESCRIPTION
## Summary
- Add `cooldown` block (7-day default, 14-day semver-major) to Dependabot pip ecosystem entry
- Change pip update schedule from daily to weekly
- Add `exclude-newer = "7 days"` to `[tool.uv]` for additional release maturity gating
- Security updates (known CVEs) bypass cooldowns automatically

## Test plan
- [ ] Verify dependabot.yml is valid YAML and GitHub parses it correctly
- [ ] Verify pyproject.toml remains valid for uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)