### PR TITLE
docs: add annotation queues and scores to comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Comparison with [official Langfuse MCP](https://github.com/langfuse/mcp-server-l
 | **Exception Tracking** | Yes | No |
 | **Prompt Management** | Yes | Yes |
 | **Dataset Management** | Yes | No |
+| **Annotation Queues** | Yes | No |
+| **Scores (v2)** | Yes | No |
 | **Selective Tool Loading** | Yes | No |
 
-This project provides a **full observability toolkit** — traces, observations, sessions, exceptions, and prompts — while the official MCP focuses on prompt management.
+This project provides a **full observability toolkit** — traces, observations, sessions, exceptions, prompts, datasets, annotation queues, and scores — while the official MCP focuses on prompt management.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Add Annotation Queues and Scores (v2) rows to the README comparison table
- Update summary line to include datasets, annotation queues, and scores

Supersedes #20 — credits to @nikhildigde for flagging the gap.

## Test plan

- [ ] Verify table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)