### PR TITLE
ci(release): harden Python publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write
+    env:
+      PYPI_TOKEN_PRESENT: ${{ secrets.PYPI_API_TOKEN != '' && 'true' || 'false' }}
     steps:
       - name: Download release distributions
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -294,7 +297,12 @@ jobs:
           name: release-dists
           path: dist/
 
-      - name: Publish to PyPI
+      - name: Publish to PyPI with trusted publishing
+        if: env.PYPI_TOKEN_PRESENT != 'true'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+
+      - name: Publish to PyPI with API token fallback
+        if: env.PYPI_TOKEN_PRESENT == 'true'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ on:
           - pypi-only
           - skills-only
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
   cancel-in-progress: false
@@ -171,6 +174,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -211,6 +216,27 @@ jobs:
         run: |
           rm -rf dist
           uv build --python 3.12
+
+      - name: Collect attestation subjects
+        id: attestation_subjects
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t subjects < <(find dist -maxdepth 1 -type f | sort)
+          if ((${#subjects[@]} == 0)); then
+            echo "::error::No release artifacts found to attest."
+            exit 1
+          fi
+          {
+            echo "subjects<<EOF"
+            printf '%s\n' "${subjects[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ${{ steps.attestation_subjects.outputs.subjects }}
 
       - name: Extract release notes for this tag
         shell: bash


### PR DESCRIPTION
## Summary
- attest Python release artifacts
- prefer PyPI trusted publishing with API token fallback
- keep the existing release PR + verification flow intact