### PR TITLE
chore(dependabot): ignore langfuse major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+    ignore:
+      - dependency-name: "langfuse"
+        update-types:
+          - "version-update:semver-major"
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary
- ignore semver-major updates for `langfuse`
- avoid reopening the incompatible v4 SDK bump as an ordinary Dependabot PR
- keep room for a dedicated migration later

## Validation
- config-only change
- existing red PR #16 fails because the v4 SDK breaks current imports and call shapes