### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-26
 ### Added
 - Added `--default-output-mode` and `LANGFUSE_MCP_DEFAULT_OUTPUT_MODE` so MCP tool schemas can default to `compact`, `full_json_string`, or `full_json_file` when clients omit `output_mode`.
 
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned all GitHub Actions to commit SHAs across every workflow for supply-chain safety.
 - Added missing `permissions`, `timeout-minutes`, and `concurrency` blocks to all workflows.
 - Standalone publish workflows now accept `workflow_dispatch` with an explicit `tag` input and check out the tag ref, making manual reruns safe regardless of branch context.
+
 
 ## [0.6.5] - 2026-04-02
 ### Changed

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse
-version: 0.6.5
+version: 0.7.0
 description: Debug AI traces, find exceptions, analyze sessions, and manage prompts via Langfuse MCP. Use when debugging AI pipelines, investigating errors, analyzing latency, managing prompt versions, or setting up Langfuse. Triggers on "langfuse", "traces", "debug AI", "find exceptions", "what went wrong", "why is it slow", "datasets", "evaluation sets".
 metadata:
   short-description: Langfuse observability via MCP


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.7.0`
- aligns skill/plugin metadata to `0.7.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.7.0`, publishes the GitHub release, then publishes to PyPI, Docker (GHCR), and the skills marketplace in the same workflow run