### PR TITLE
feat: configurable lookback cap via LANGFUSE_MAX_AGE_DAYS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ docker run --rm -i \
   ghcr.io/avivsinai/langfuse-mcp:latest
 ```
 
+### Optional environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `LANGFUSE_MAX_AGE_DAYS` | `7` | Caps the lookback window for time-based tools (`fetch_traces`, `fetch_observations`, etc.). Set to match your Langfuse instance's data retention — e.g. `30` if your retention is 30 days. |
+
 ## Development
 
 ```bash

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -88,7 +88,10 @@ logger = logging.getLogger("langfuse_mcp")
 # Constants
 HOUR = 60  # minutes
 DAY = 24 * HOUR
-MAX_AGE_MINUTES = 7 * DAY
+# MAX_AGE_MINUTES caps the lookback window for time-based tools (fetch_traces,
+# fetch_observations, etc.) — set to match your Langfuse instance's data
+# retention. Override via LANGFUSE_MAX_AGE_DAYS env var; defaults to 7 days.
+MAX_AGE_MINUTES = int(os.environ.get("LANGFUSE_MAX_AGE_DAYS", "7")) * DAY
 MAX_FIELD_LENGTH = 500  # Maximum string length for field values
 MAX_RESPONSE_SIZE = 20000  # Maximum size of response object in characters
 TRUNCATE_SUFFIX = "..."  # Suffix to add to truncated fields
@@ -959,7 +962,7 @@ def validate_age(age: int) -> int:
         The validated age if it passes validation
 
     Raises:
-        ValueError: If age is not positive or exceeds 7 days (10080 minutes)
+        ValueError: If age is not positive or exceeds MAX_AGE_MINUTES
     """
     if age <= 0:
         raise ValueError("Age must be positive")
@@ -970,7 +973,7 @@ def validate_age(age: int) -> int:
 
 
 ValidatedAge = Annotated[int, AfterValidator(validate_age)]
-"""Type for validated age values (positive integer up to 7 days/10080 minutes)"""
+"""Type for validated age values (positive integer up to MAX_AGE_MINUTES)"""
 
 
 def clear_caches(state: MCPState) -> None:
@@ -1804,7 +1807,7 @@ async def get_user_sessions(
 async def find_exceptions(
     ctx: Context,
     age: ValidatedAge = Field(
-        ..., description="Number of minutes to look back (positive integer, max 7 days/10080 minutes)", gt=0, le=MAX_AGE_MINUTES
+        ..., description=f"Number of minutes to look back (positive integer, max {MAX_AGE_MINUTES // DAY} days)", gt=0, le=MAX_AGE_MINUTES
     ),
     group_by: Literal["file", "function", "type"] = Field(
         "file",
@@ -1817,7 +1820,7 @@ async def find_exceptions(
 
     Args:
         ctx: Context object containing lifespan context with Langfuse client
-        age: Number of minutes to look back (positive integer, max 7 days/10080 minutes)
+        age: Number of minutes to look back (positive integer, max 30 days)
         group_by: How to group exceptions - "file" groups by filename, "function" groups by function name,
                   or "type" groups by exception type
 
@@ -1895,7 +1898,7 @@ async def find_exceptions_in_file(
     ctx: Context,
     filepath: str = Field(..., description="Path to the file to search for exceptions (full path including extension)"),
     age: ValidatedAge = Field(
-        ..., description="Number of minutes to look back (positive integer, max 7 days/10080 minutes)", gt=0, le=MAX_AGE_MINUTES
+        ..., description=f"Number of minutes to look back (positive integer, max {MAX_AGE_MINUTES // DAY} days)", gt=0, le=MAX_AGE_MINUTES
     ),
     output_mode: OUTPUT_MODE_LITERAL = Field(
         "compact",
@@ -1912,7 +1915,7 @@ async def find_exceptions_in_file(
     Args:
         ctx: Context object containing lifespan context with Langfuse client
         filepath: Path to the file to search for exceptions (full path including extension)
-        age: Number of minutes to look back (positive integer, max 7 days/10080 minutes)
+        age: Number of minutes to look back (positive integer, max 30 days)
         output_mode: Controls the output format and detail level
 
     Returns:
@@ -2148,14 +2151,14 @@ async def get_exception_details(
 async def get_error_count(
     ctx: Context,
     age: ValidatedAge = Field(
-        ..., description="Number of minutes to look back (positive integer, max 7 days/10080 minutes)", gt=0, le=MAX_AGE_MINUTES
+        ..., description=f"Number of minutes to look back (positive integer, max {MAX_AGE_MINUTES // DAY} days)", gt=0, le=MAX_AGE_MINUTES
     ),
 ) -> ResponseDict:
     """Get number of traces with exceptions in last N minutes.
 
     Args:
         ctx: Context object containing lifespan context with Langfuse client
-        age: Number of minutes to look back (positive integer, max 7 days/10080 minutes)
+        age: Number of minutes to look back (positive integer, max 30 days)
 
     Returns:
         Dictionary with error statistics including trace count, observation count, and exception count

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -88,10 +88,27 @@ logger = logging.getLogger("langfuse_mcp")
 # Constants
 HOUR = 60  # minutes
 DAY = 24 * HOUR
+DEFAULT_MAX_AGE_DAYS = 7
+
+
+def _read_max_age_days() -> int:
+    """Read the configured maximum lookback window in days."""
+    raw_value = os.environ.get("LANGFUSE_MAX_AGE_DAYS", str(DEFAULT_MAX_AGE_DAYS))
+    try:
+        max_age_days = int(raw_value)
+    except ValueError as exc:
+        raise ValueError("LANGFUSE_MAX_AGE_DAYS must be an integer number of days") from exc
+    if max_age_days <= 0:
+        raise ValueError("LANGFUSE_MAX_AGE_DAYS must be a positive integer")
+    return max_age_days
+
+
 # MAX_AGE_MINUTES caps the lookback window for time-based tools (fetch_traces,
-# fetch_observations, etc.) — set to match your Langfuse instance's data
-# retention. Override via LANGFUSE_MAX_AGE_DAYS env var; defaults to 7 days.
-MAX_AGE_MINUTES = int(os.environ.get("LANGFUSE_MAX_AGE_DAYS", "7")) * DAY
+# fetch_observations, etc.). Set to match your Langfuse instance's data
+# retention. Override via LANGFUSE_MAX_AGE_DAYS env var.
+MAX_AGE_DAYS = _read_max_age_days()
+MAX_AGE_MINUTES = MAX_AGE_DAYS * DAY
+AGE_LOOKBACK_DESCRIPTION = f"Number of minutes to look back (positive integer, max {MAX_AGE_DAYS} days/{MAX_AGE_MINUTES} minutes)"
 MAX_FIELD_LENGTH = 500  # Maximum string length for field values
 MAX_RESPONSE_SIZE = 20000  # Maximum size of response object in characters
 TRUNCATE_SUFFIX = "..."  # Suffix to add to truncated fields
@@ -953,7 +970,7 @@ class ExceptionCount(BaseModel):
 
 
 def validate_age(age: int) -> int:
-    """Validate that age is positive and ≤ 7 days.
+    """Validate that age is positive and within the configured maximum.
 
     Args:
         age: Age in minutes to validate
@@ -962,7 +979,7 @@ def validate_age(age: int) -> int:
         The validated age if it passes validation
 
     Raises:
-        ValueError: If age is not positive or exceeds MAX_AGE_MINUTES
+        ValueError: If age is not positive or exceeds the configured maximum
     """
     if age <= 0:
         raise ValueError("Age must be positive")
@@ -973,7 +990,7 @@ def validate_age(age: int) -> int:
 
 
 ValidatedAge = Annotated[int, AfterValidator(validate_age)]
-"""Type for validated age values (positive integer up to MAX_AGE_MINUTES)"""
+"""Type for validated age values within the configured maximum lookback window."""
 
 
 def clear_caches(state: MCPState) -> None:
@@ -1806,9 +1823,7 @@ async def get_user_sessions(
 
 async def find_exceptions(
     ctx: Context,
-    age: ValidatedAge = Field(
-        ..., description=f"Number of minutes to look back (positive integer, max {MAX_AGE_MINUTES // DAY} days)", gt=0, le=MAX_AGE_MINUTES
-    ),
+    age: ValidatedAge = Field(..., description=AGE_LOOKBACK_DESCRIPTION, gt=0, le=MAX_AGE_MINUTES),
     group_by: Literal["file", "function", "type"] = Field(
         "file",
         description=(
@@ -1820,7 +1835,7 @@ async def find_exceptions(
 
     Args:
         ctx: Context object containing lifespan context with Langfuse client
-        age: Number of minutes to look back (positive integer, max 30 days)
+        age: Number of minutes to look back; capped by the configured maximum
         group_by: How to group exceptions - "file" groups by filename, "function" groups by function name,
                   or "type" groups by exception type
 
@@ -1897,9 +1912,7 @@ async def find_exceptions(
 async def find_exceptions_in_file(
     ctx: Context,
     filepath: str = Field(..., description="Path to the file to search for exceptions (full path including extension)"),
-    age: ValidatedAge = Field(
-        ..., description=f"Number of minutes to look back (positive integer, max {MAX_AGE_MINUTES // DAY} days)", gt=0, le=MAX_AGE_MINUTES
-    ),
+    age: ValidatedAge = Field(..., description=AGE_LOOKBACK_DESCRIPTION, gt=0, le=MAX_AGE_MINUTES),
     output_mode: OUTPUT_MODE_LITERAL = Field(
         "compact",
         description=(
@@ -1915,7 +1928,7 @@ async def find_exceptions_in_file(
     Args:
         ctx: Context object containing lifespan context with Langfuse client
         filepath: Path to the file to search for exceptions (full path including extension)
-        age: Number of minutes to look back (positive integer, max 30 days)
+        age: Number of minutes to look back; capped by the configured maximum
         output_mode: Controls the output format and detail level
 
     Returns:
@@ -2150,15 +2163,13 @@ async def get_exception_details(
 
 async def get_error_count(
     ctx: Context,
-    age: ValidatedAge = Field(
-        ..., description=f"Number of minutes to look back (positive integer, max {MAX_AGE_MINUTES // DAY} days)", gt=0, le=MAX_AGE_MINUTES
-    ),
+    age: ValidatedAge = Field(..., description=AGE_LOOKBACK_DESCRIPTION, gt=0, le=MAX_AGE_MINUTES),
 ) -> ResponseDict:
     """Get number of traces with exceptions in last N minutes.
 
     Args:
         ctx: Context object containing lifespan context with Langfuse client
-        age: Number of minutes to look back (positive integer, max 30 days)
+        age: Number of minutes to look back; capped by the configured maximum
 
     Returns:
         Dictionary with error statistics including trace count, observation count, and exception count

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,8 @@
 """Basic tests for langfuse-mcp package."""
 
+import importlib
 import logging
+import os
 import sys
 
 import pytest
@@ -34,6 +36,27 @@ def test_cli_env_defaults(monkeypatch):
     assert args.host == "https://env-host"
     assert args.log_level == "DEBUG"
     assert args.log_to_console is True
+
+
+def test_max_age_days_env_override(monkeypatch):
+    """LANGFUSE_MAX_AGE_DAYS should configure the lookback cap at import time."""
+    import langfuse_mcp.__main__ as main_module
+
+    original_env_value = os.environ.get("LANGFUSE_MAX_AGE_DAYS")
+    try:
+        monkeypatch.setenv("LANGFUSE_MAX_AGE_DAYS", "30")
+        reloaded = importlib.reload(main_module)
+
+        assert reloaded.MAX_AGE_DAYS == 30
+        assert reloaded.MAX_AGE_MINUTES == 30 * reloaded.DAY
+        assert "max 30 days/43200 minutes" in reloaded.AGE_LOOKBACK_DESCRIPTION
+        assert reloaded.validate_age(30 * reloaded.DAY) == 30 * reloaded.DAY
+    finally:
+        if original_env_value is None:
+            monkeypatch.delenv("LANGFUSE_MAX_AGE_DAYS", raising=False)
+        else:
+            monkeypatch.setenv("LANGFUSE_MAX_AGE_DAYS", original_env_value)
+        importlib.reload(main_module)
 
 
 def test_cli_requires_keys_without_env(monkeypatch):


### PR DESCRIPTION
## Summary

Make the lookback cap (`MAX_AGE_MINUTES`) configurable via the `LANGFUSE_MAX_AGE_DAYS` env var. Defaults to **7 days** to preserve current behavior; deployments with longer Langfuse retention (e.g. 30 days at my company) can simply set the env var to match.

## Motivation

Self-hosted Langfuse instances often retain data longer than 7 days, but the hardcoded `MAX_AGE_MINUTES = 7 * DAY` in `__main__.py` causes time-based tools (`fetch_traces`, `fetch_observations`, `find_exceptions`, `get_user_sessions`) to reject any `age > 10080`. The Pydantic `le=MAX_AGE_MINUTES` constraint surfaces as a JSON-schema `maximum: 10080`, which clients see at tool-discovery time — they can't even attempt a longer query.

Concrete use case: I needed to replay traces from up to 21 days ago to capture LLM regression cases as golden tests. The data was still in our Langfuse, but the MCP wrapper refused to issue the query.

## Changes

- `MAX_AGE_MINUTES` is now derived from `LANGFUSE_MAX_AGE_DAYS` env var, defaulting to `7`.
- The four `Field(...)` definitions for `age` parameters use an f-string that reflects the actual limit, so client-visible tool schemas show the right number when the cap is overridden.
- README adds a small "Optional environment variables" table documenting the new var.

No behavior change for default deployments — the cap stays at 7 days unless you opt in.

## Verified

```sh
$ LANGFUSE_MAX_AGE_DAYS=30 uv run python -c "import langfuse_mcp.__main__ as m; print(m.MAX_AGE_MINUTES)"
43200

$ uv run python -c "import langfuse_mcp.__main__ as m; print(m.MAX_AGE_MINUTES)"  # default
10080
```

Tool schemas re-rendered with `LANGFUSE_MAX_AGE_DAYS=30` correctly show `"maximum": 43200` and description `"max 30 days"`.