### PR TITLE
docs(changelog): note LANGFUSE_MAX_AGE_DAYS in unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `LANGFUSE_MAX_AGE_DAYS` env var lets deployments override the 7-day lookback cap on time-based tools (`fetch_traces`, `fetch_observations`, `find_exceptions`, `get_user_sessions`, etc.) to match longer Langfuse retention windows. Tool schema descriptions now reflect the configured cap.
 
 ## [0.7.0] - 2026-04-26
 ### Added


### PR DESCRIPTION
## Summary
- Backfill the Unreleased changelog entry for `LANGFUSE_MAX_AGE_DAYS` (added in #34) so the next release picks it up.

## Test plan
- [ ] CI green (lint/test)
- [ ] Followed by `./scripts/release.sh 0.8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)