### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.0] - 2026-04-28
 ### Added
 - `LANGFUSE_MAX_AGE_DAYS` env var lets deployments override the 7-day lookback cap on time-based tools (`fetch_traces`, `fetch_observations`, `find_exceptions`, `get_user_sessions`, etc.) to match longer Langfuse retention windows. Tool schema descriptions now reflect the configured cap.
+
 
 ## [0.7.0] - 2026-04-26
 ### Added

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse
-version: 0.7.0
+version: 0.8.0
 description: Debug AI traces, find exceptions, analyze sessions, and manage prompts via Langfuse MCP. Use when debugging AI pipelines, investigating errors, analyzing latency, managing prompt versions, or setting up Langfuse. Triggers on "langfuse", "traces", "debug AI", "find exceptions", "what went wrong", "why is it slow", "datasets", "evaluation sets".
 metadata:
   short-description: Langfuse observability via MCP


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.8.0`
- aligns skill/plugin metadata to `0.8.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.8.0`, publishes the GitHub release, then publishes to PyPI, Docker (GHCR), and the skills marketplace in the same workflow run