### PR TITLE
fix(uv): remove malformed exclude-newer setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,6 @@ combine-as-imports = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.uv]
-exclude-newer = "7 days"
-
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"


### PR DESCRIPTION
**ON HOLD — pushback received.** The `exclude-newer` line is a supply-chain defense (block packages published in the last 7 days from being pulled in), not redundant with dependabot cooldown. Investigating the right syntax/mechanism instead of deleting.