### PR TITLE
Revert "fix(uv): remove malformed exclude-newer setting"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ combine-as-imports = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"


### PR DESCRIPTION
## Summary
Reverts #37. The `exclude-newer = "7 days"` line was a real supply-chain defense, not malformed config. Removing it was a mistake.

**Why the original PR was wrong:**
- uv ≥ 0.9 supports relative durations in `exclude-newer` via [astral-sh/uv#16814](https://github.com/astral-sh/uv/issues/16814) (closed 2025-12-09). uv parses `"7 days"`, resolves it to a concrete timestamp at lock time, and pins it in the lockfile until `--upgrade`.
- The effect: `uv lock` / `uv sync` won't pull any package version published in the last 7 days — preventing freshly-published malicious versions from landing in resolution.
- The "warning" I observed locally was because my brew uv is 0.5.13 (Dec 2024, predates the feature). CI uses `astral-sh/setup-uv@v3` unpinned and gets the latest, where the gate works as intended.
- Dependabot's `cooldown` setting only delays *PR generation*, not regular `uv lock` resolution by developers — the two are complementary, not redundant.

**Why a follow-up was wrong (not just the diagnosis):** even if a config setting is "broken" on one toolchain, deleting it without confirming intent removes the documented protection. Should have asked first. My mistake.

## Test plan
- [x] Restored line matches what was on main pre-#37
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)