### PR TITLE
feat(langfuse): support langfuse v4.x via capability-based compat shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow `langfuse>=4.0.0,<5.0.0` alongside the existing `>=3.11.2,<4.0.0` range so projects can pin langfuse-mcp without blocking the v4.x SDK upgrade (closes #40).
+- Added a small capability-based shim (`langfuse_mcp/_compat.py`) so MCP tool calls auto-select the right SDK surface across SDK versions:
+  - Score list/get routing now follows the `api.scores` (v4) ↔ `api.score_v_2` (v3) rename, and the v4 method rename `get` → `get_many`. Score creation tools are unchanged.
+  - Annotation queue write tools now branch between v3's `request=<PydanticModel>` style and v4's direct-kwargs style. Path identifiers (`queue_id`, `item_id`) are passed as keyword args in both branches.
+  - Single observation fetch precedence is `api.observations.get` (v3) → `api.legacy.observations_v1.get` (v4 self-host safe) → top-level `client.fetch_observation` shim.
+- `fetch_observations` keeps its existing `page` + `limit` MCP schema. On v4 deployments where only the cursor-based `observations_v2` route is exposed, requests for `page > 1` raise an explicit `ERR_LANGFUSE_OBSERVATIONS_CURSOR_PAGE_UNSUPPORTED` error pointing at `legacy.observations_v1` rather than silently returning page 1.
+- `_extract_items_from_response` now preserves `meta` pagination on responses with `data + meta` (previously dropped on the `.data` branch).
+
+### Notes
+- v4 adds `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` as transitive dependencies. langfuse-mcp instantiates the client with `tracing_enabled=False`, so no traces are emitted by default.
+- Real-SDK smoke verification: live `Langfuse` import + `_compat` dispatcher selection probed against `langfuse==3.14.5` and `langfuse==4.5.1` for the observation list/fetch paths. The annotation queue, dataset, dataset-item, and score paths are verified by source-level signature inspection of `langfuse-python` v4.0.6 and the corresponding v3 SDK; runtime exercise lives in v3-shape and strict-v4-shape fakes that mirror the real SDK signatures (no `**kwargs` permissiveness on v4 write methods).
 
 ## [0.8.0] - 2026-04-28
 ### Added

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -35,6 +35,8 @@ from langfuse import Langfuse
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import AfterValidator, BaseModel, Field
 
+from langfuse_mcp import _compat
+
 try:
     from pydantic.fields import FieldInfo
 except ImportError:  # pragma: no cover - pydantic stubbed in tests
@@ -514,14 +516,14 @@ def _coerce_optional_datetime(value: Any, field_name: str) -> datetime | None:
 
 
 def _prompts_get(prompts_client: Any, *, name: str, **kwargs: Any) -> Any:
-    """Call prompts.get with the correct parameter name across SDK versions."""
-    try:
-        params = inspect.signature(prompts_client.get).parameters
-    except (TypeError, ValueError):
-        params = {}
+    """Call prompts.get with the correct parameter name across SDK versions.
 
+    When signature inspection fails (``method_has_param`` returns ``None``),
+    fall back to the older ``name=`` shape — matching the prior behavior
+    before the helper was tri-state.
+    """
     call_kwargs = dict(kwargs)
-    if "prompt_name" in params:
+    if _compat.method_has_param(prompts_client.get, "prompt_name") is True:
         call_kwargs["prompt_name"] = name
     else:
         call_kwargs["name"] = name
@@ -530,11 +532,8 @@ def _prompts_get(prompts_client: Any, *, name: str, **kwargs: Any) -> Any:
 
 
 def _prompts_get_supports_resolve(prompts_client: Any) -> bool:
-    try:
-        params = inspect.signature(prompts_client.get).parameters
-    except (TypeError, ValueError):
-        return False
-    return "resolve" in params
+    """Return True when the SDK's prompts.get accepts the ``resolve`` kwarg."""
+    return _compat.method_has_param(prompts_client.get, "resolve") is True
 
 
 def _extract_items_from_response(response: Any) -> tuple[list[Any], dict[str, Any]]:
@@ -556,7 +555,9 @@ def _extract_items_from_response(response: Any) -> tuple[list[Any], dict[str, An
         return list(items), pagination
 
     if hasattr(response, "data"):
-        return list(response.data), {}
+        meta = getattr(response, "meta", None)
+        pagination = _sdk_object_to_python(meta) if meta is not None else {}
+        return list(response.data), pagination if isinstance(pagination, dict) else {}
 
     if isinstance(response, list):
         return response, {}
@@ -632,13 +633,14 @@ def _list_observations(
     parent_observation_id: str | None,
     metadata: dict[str, Any] | None,
 ) -> tuple[list[Any], dict[str, Any]]:
-    """Fetch observations via the Langfuse SDK handling v2/v3 differences."""
-    if not hasattr(langfuse_client, "api") or not hasattr(langfuse_client.api, "observations"):
+    """Fetch observations via the Langfuse SDK handling v3 page-based and v4 cursor-based listings."""
+    list_method = _compat.get_observations_list_method(langfuse_client)
+    if list_method is None:
         raise RuntimeError("Unsupported Langfuse client: no observation listing method available")
+    method, mode = list_method
 
     list_kwargs: dict[str, Any] = {
         "limit": limit or None,
-        "page": page or None,
         "name": name,
         "user_id": user_id,
         "type": obs_type,
@@ -647,9 +649,23 @@ def _list_observations(
         "from_start_time": from_start_time,
         "to_start_time": to_start_time,
     }
+
+    if mode == "page":
+        list_kwargs["page"] = page or None
+    else:
+        # v4 ObservationsV2 endpoint uses cursor-based pagination only. Page=1 maps to
+        # an empty cursor (first page); higher page numbers cannot be honored without
+        # walking, so surface a clear error rather than silently returning page=1.
+        if page > 1:
+            raise RuntimeError(
+                "ERR_LANGFUSE_OBSERVATIONS_CURSOR_PAGE_UNSUPPORTED: "
+                "Retry with page=1; this MCP schema cannot request page>1 unless the "
+                "active Langfuse client exposes api.legacy.observations_v1 (page-based)."
+            )
+
     list_kwargs = {k: v for k, v in list_kwargs.items() if v is not None}
 
-    response = langfuse_client.api.observations.get_many(**list_kwargs)
+    response = method(**list_kwargs)
     items, pagination = _extract_items_from_response(response)
 
     if metadata:
@@ -660,15 +676,11 @@ def _list_observations(
 
 
 def _get_observation(langfuse_client: Any, observation_id: str) -> Any:
-    """Fetch a single observation using either the v3 or v2 SDK surface."""
-    if hasattr(langfuse_client, "api") and hasattr(langfuse_client.api, "observations"):
-        return langfuse_client.api.observations.get(observation_id=observation_id)
-
-    if hasattr(langfuse_client, "fetch_observation"):
-        response = langfuse_client.fetch_observation(observation_id)
-        return getattr(response, "data", response)
-
-    raise RuntimeError("Unsupported Langfuse client: no observation getter available")
+    """Fetch a single observation; precedence is v3 -> v4 legacy_v1 -> top-level shim."""
+    fetcher = _compat.get_observations_single_fetcher(langfuse_client)
+    if fetcher is None:
+        raise RuntimeError("Unsupported Langfuse client: no observation getter available")
+    return fetcher(observation_id)
 
 
 def _get_trace(langfuse_client: Any, trace_id: str, include_observations: bool) -> Any:
@@ -3243,23 +3255,18 @@ async def create_dataset(
         description = _normalize_field_default(description)
         metadata = _normalize_field_default(metadata)
 
-        # Use the high-level SDK method if available, otherwise use API directly
-        if hasattr(state.langfuse_client, "create_dataset"):
-            kwargs: dict[str, Any] = {"name": name}
-            if description:
-                kwargs["description"] = description
-            if metadata:
-                kwargs["metadata"] = metadata
-            dataset = state.langfuse_client.create_dataset(**kwargs)
-        else:
-            from langfuse.api.resources.datasets.types.create_dataset_request import CreateDatasetRequest
+        kwargs: dict[str, Any] = {"name": name}
+        if description is not None:
+            kwargs["description"] = description
+        if metadata is not None:
+            kwargs["metadata"] = metadata
 
-            request = CreateDatasetRequest(
-                name=name,
-                description=description,
-                metadata=metadata,
-            )
-            dataset = state.langfuse_client.api.datasets.create(request=request)
+        # Both supported SDKs (v3 ≥3.11.2, v4 ≥4.0.0) expose the top-level
+        # ``Langfuse.create_dataset`` shortcut, so we don't ship a v3/v4 fallback
+        # for ``api.datasets.create`` that would never run in practice.
+        if not hasattr(state.langfuse_client, "create_dataset"):
+            raise RuntimeError("Unsupported Langfuse client: missing top-level create_dataset() shortcut")
+        dataset = state.langfuse_client.create_dataset(**kwargs)
 
         result = _sdk_object_to_python(dataset)
 
@@ -3317,47 +3324,28 @@ async def create_dataset_item(
         item_id = _normalize_field_default(item_id)
         status = _normalize_field_default(status)
 
-        # Use the high-level SDK method if available
-        if hasattr(state.langfuse_client, "create_dataset_item"):
-            kwargs: dict[str, Any] = {"dataset_name": dataset_name}
-            if input is not None:
-                kwargs["input"] = input
-            if expected_output is not None:
-                kwargs["expected_output"] = expected_output
-            if metadata:
-                kwargs["metadata"] = metadata
-            if source_trace_id:
-                kwargs["source_trace_id"] = source_trace_id
-            if source_observation_id:
-                kwargs["source_observation_id"] = source_observation_id
-            if item_id:
-                kwargs["id"] = item_id
-            if status:
-                kwargs["status"] = status
-            item = state.langfuse_client.create_dataset_item(**kwargs)
-        else:
-            from langfuse.api.resources.dataset_items.types.create_dataset_item_request import CreateDatasetItemRequest
+        kwargs: dict[str, Any] = {"dataset_name": dataset_name}
+        if input is not None:
+            kwargs["input"] = input
+        if expected_output is not None:
+            kwargs["expected_output"] = expected_output
+        if metadata is not None:
+            kwargs["metadata"] = metadata
+        if source_trace_id is not None:
+            kwargs["source_trace_id"] = source_trace_id
+        if source_observation_id is not None:
+            kwargs["source_observation_id"] = source_observation_id
+        if item_id is not None:
+            kwargs["id"] = item_id
+        if status is not None:
+            kwargs["status"] = status
 
-            request_kwargs: dict[str, Any] = {"dataset_name": dataset_name}
-            if input is not None:
-                request_kwargs["input"] = input
-            if expected_output is not None:
-                request_kwargs["expected_output"] = expected_output
-            if metadata:
-                request_kwargs["metadata"] = metadata
-            if source_trace_id:
-                request_kwargs["source_trace_id"] = source_trace_id
-            if source_observation_id:
-                request_kwargs["source_observation_id"] = source_observation_id
-            if item_id:
-                request_kwargs["id"] = item_id
-            if status:
-                from langfuse.api.resources.commons.types.dataset_status import DatasetStatus
-
-                request_kwargs["status"] = DatasetStatus(status)
-
-            request = CreateDatasetItemRequest(**request_kwargs)
-            item = state.langfuse_client.api.dataset_items.create(request=request)
+        # As with create_dataset above, both supported SDKs expose the top-level
+        # ``Langfuse.create_dataset_item`` shortcut, so the api-level fallback
+        # would never run for any supported client.
+        if not hasattr(state.langfuse_client, "create_dataset_item"):
+            raise RuntimeError("Unsupported Langfuse client: missing top-level create_dataset_item() shortcut")
+        item = state.langfuse_client.create_dataset_item(**kwargs)
 
         result = _sdk_object_to_python(item)
 
@@ -3446,16 +3434,20 @@ async def create_annotation_queue(
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
         description = _normalize_field_default(description)
-        score_config_ids = _normalize_field_default(score_config_ids)
+        # Both v3 (CreateAnnotationQueueRequest) and v4 (api.annotation_queues.create_queue)
+        # treat score_config_ids as a required list — passing None triggers a Pydantic
+        # validation error. Coerce omissions to [] so the MCP-level "optional" semantics
+        # don't leak through to the SDK call.
+        score_config_ids = _normalize_field_default(score_config_ids) or []
 
-        try:
-            from langfuse.api.resources.annotation_queues.types.create_annotation_queue_request import CreateAnnotationQueueRequest
-
-            request: Any = CreateAnnotationQueueRequest(name=name, description=description, score_config_ids=score_config_ids)  # type: ignore[call-arg]  # SDK uses camelCase aliases
-        except (ImportError, ModuleNotFoundError):
-            request = {"name": name, "description": description, "score_config_ids": score_config_ids}
-
-        queue = state.langfuse_client.api.annotation_queues.create_queue(request=request)
+        method = state.langfuse_client.api.annotation_queues.create_queue
+        queue = _compat.call_with_request_or_kwargs(
+            method,
+            lambda: _build_create_annotation_queue_request(name=name, description=description, score_config_ids=score_config_ids),
+            name=name,
+            description=description,
+            score_config_ids=score_config_ids,
+        )
         result = _sdk_object_to_python(queue)
         logger.info(f"Created annotation queue '{name}' (id={result.get('id')})")
         return {"data": result, "metadata": {"created": True, "queue_id": result.get("id"), "name": name}}
@@ -3543,20 +3535,17 @@ async def create_annotation_queue_item(
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
         status = _normalize_field_default(status)
-        request_kwargs: dict[str, Any] = {"object_id": object_id, "object_type": object_type}
+        body_kwargs: dict[str, Any] = {"object_id": object_id, "object_type": object_type}
         if status is not None:
-            request_kwargs["status"] = status
+            body_kwargs["status"] = status
 
-        try:
-            from langfuse.api.resources.annotation_queues.types.create_annotation_queue_item_request import (
-                CreateAnnotationQueueItemRequest,
-            )
-
-            request: Any = CreateAnnotationQueueItemRequest(**request_kwargs)
-        except (ImportError, ModuleNotFoundError):
-            request = request_kwargs
-
-        item = state.langfuse_client.api.annotation_queues.create_queue_item(queue_id=queue_id, request=request)
+        method = state.langfuse_client.api.annotation_queues.create_queue_item
+        item = _compat.call_with_request_or_kwargs(
+            method,
+            lambda: _build_create_annotation_queue_item_request(**body_kwargs),
+            path_kwargs={"queue_id": queue_id},
+            **body_kwargs,
+        )
         result = _sdk_object_to_python(item)
         logger.info(f"Created annotation queue item '{result.get('id')}' in queue '{queue_id}'")
         return {"data": result, "metadata": {"created": True, "queue_id": queue_id, "item_id": result.get("id")}}
@@ -3574,16 +3563,13 @@ async def update_annotation_queue_item(
     """Update the status of an annotation queue item."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        try:
-            from langfuse.api.resources.annotation_queues.types.update_annotation_queue_item_request import (
-                UpdateAnnotationQueueItemRequest,
-            )
-
-            request: Any = UpdateAnnotationQueueItemRequest(status=status)  # type: ignore[arg-type]  # SDK accepts str via validator
-        except (ImportError, ModuleNotFoundError):
-            request = {"status": status}
-
-        item = state.langfuse_client.api.annotation_queues.update_queue_item(queue_id=queue_id, item_id=item_id, request=request)
+        method = state.langfuse_client.api.annotation_queues.update_queue_item
+        item = _compat.call_with_request_or_kwargs(
+            method,
+            lambda: _build_update_annotation_queue_item_request(status=status),
+            path_kwargs={"queue_id": queue_id, "item_id": item_id},
+            status=status,
+        )
         result = _sdk_object_to_python(item)
         logger.info(f"Updated annotation queue item '{item_id}' in queue '{queue_id}'")
         return {"data": result, "metadata": {"updated": True, "queue_id": queue_id, "item_id": item_id}}
@@ -3609,6 +3595,42 @@ async def delete_annotation_queue_item(
         raise
 
 
+def _build_create_annotation_queue_request(*, name: str, description: str | None, score_config_ids: list[str] | None) -> Any:
+    """Construct the v3 ``CreateAnnotationQueueRequest`` body for queue create writes."""
+    return _compat.resolve_request_model(
+        "annotation_queues",
+        "create_annotation_queue_request",
+        "CreateAnnotationQueueRequest",
+    )(name=name, description=description, score_config_ids=score_config_ids)
+
+
+def _build_create_annotation_queue_item_request(**kwargs: Any) -> Any:
+    """Construct the v3 ``CreateAnnotationQueueItemRequest`` body for queue-item create writes."""
+    return _compat.resolve_request_model(
+        "annotation_queues",
+        "create_annotation_queue_item_request",
+        "CreateAnnotationQueueItemRequest",
+    )(**kwargs)
+
+
+def _build_update_annotation_queue_item_request(*, status: str) -> Any:
+    """Construct the v3 ``UpdateAnnotationQueueItemRequest`` body for queue-item update writes."""
+    return _compat.resolve_request_model(
+        "annotation_queues",
+        "update_annotation_queue_item_request",
+        "UpdateAnnotationQueueItemRequest",
+    )(status=status)
+
+
+def _build_annotation_queue_assignment_request(user_id: str) -> Any:
+    """Construct the v3 ``AnnotationQueueAssignmentRequest`` body for assignment writes."""
+    return _compat.resolve_request_model(
+        "annotation_queues",
+        "annotation_queue_assignment_request",
+        "AnnotationQueueAssignmentRequest",
+    )(user_id=user_id)
+
+
 async def create_annotation_queue_assignment(
     ctx: Context,
     queue_id: str = Field(..., description="Annotation queue ID"),
@@ -3617,16 +3639,13 @@ async def create_annotation_queue_assignment(
     """Assign a user to an annotation queue."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        try:
-            from langfuse.api.resources.annotation_queues.types.annotation_queue_assignment_request import (
-                AnnotationQueueAssignmentRequest,
-            )
-
-            request: Any = AnnotationQueueAssignmentRequest(user_id=user_id)  # type: ignore[call-arg]  # SDK uses camelCase aliases
-        except (ImportError, ModuleNotFoundError):
-            request = {"user_id": user_id}
-
-        response = state.langfuse_client.api.annotation_queues.create_queue_assignment(queue_id=queue_id, request=request)
+        method = state.langfuse_client.api.annotation_queues.create_queue_assignment
+        response = _compat.call_with_request_or_kwargs(
+            method,
+            lambda: _build_annotation_queue_assignment_request(user_id),
+            path_kwargs={"queue_id": queue_id},
+            user_id=user_id,
+        )
         result = _sdk_object_to_python(response) if response else {}
         logger.info(f"Assigned user '{user_id}' to annotation queue '{queue_id}'")
         return {"data": result, "metadata": {"created": True, "queue_id": queue_id, "user_id": user_id}}
@@ -3643,16 +3662,13 @@ async def delete_annotation_queue_assignment(
     """Unassign a user from an annotation queue."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        try:
-            from langfuse.api.resources.annotation_queues.types.annotation_queue_assignment_request import (
-                AnnotationQueueAssignmentRequest,
-            )
-
-            request: Any = AnnotationQueueAssignmentRequest(user_id=user_id)  # type: ignore[call-arg]  # SDK uses camelCase aliases
-        except (ImportError, ModuleNotFoundError):
-            request = {"user_id": user_id}
-
-        response = state.langfuse_client.api.annotation_queues.delete_queue_assignment(queue_id=queue_id, request=request)
+        method = state.langfuse_client.api.annotation_queues.delete_queue_assignment
+        response = _compat.call_with_request_or_kwargs(
+            method,
+            lambda: _build_annotation_queue_assignment_request(user_id),
+            path_kwargs={"queue_id": queue_id},
+            user_id=user_id,
+        )
         result = _sdk_object_to_python(response) if response else {}
         logger.info(f"Removed user '{user_id}' assignment from annotation queue '{queue_id}'")
         return {"data": result, "metadata": {"deleted": True, "queue_id": queue_id, "user_id": user_id}}
@@ -3730,13 +3746,25 @@ async def list_scores_v2(
         }
         api_kwargs = {k: v for k, v in api_kwargs.items() if v is not None}
 
-        response = state.langfuse_client.api.score_v_2.get(**api_kwargs)
+        scores_namespace = _compat.get_score_namespace(state.langfuse_client)
+        if scores_namespace is None:
+            raise RuntimeError("Unsupported Langfuse client: no scores namespace exposed")
+        list_method = _compat.get_score_list_method(scores_namespace)
+        if list_method is None:
+            raise RuntimeError("Unsupported Langfuse client: scores namespace exposes no list method")
+
+        response = list_method(**api_kwargs)
         items, pagination = _extract_items_from_response(response)
         scores = [_sdk_object_to_python(item) for item in items]
         logger.info(f"Listed {len(scores)} scores (page={page}, limit={limit})")
         return {
             "data": scores,
-            "metadata": {"page": page, "limit": limit, "item_count": len(scores), "total": pagination.get("total")},
+            "metadata": {
+                "page": page,
+                "limit": limit,
+                "item_count": len(scores),
+                "total": pagination.get("total", pagination.get("total_items")),
+            },
         }
     except Exception as e:
         logger.error(f"Error listing scores v2: {e}")
@@ -3747,10 +3775,13 @@ async def get_score_v2(
     ctx: Context,
     score_id: str = Field(..., description="Score ID"),
 ) -> ResponseDict:
-    """Get a score by ID from the score v2 API."""
+    """Get a score by ID from the scores API (v3 ``score_v_2`` or v4 ``scores``)."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        score = state.langfuse_client.api.score_v_2.get_by_id(score_id=score_id)
+        scores_namespace = _compat.get_score_namespace(state.langfuse_client)
+        if scores_namespace is None or not hasattr(scores_namespace, "get_by_id"):
+            raise RuntimeError("Unsupported Langfuse client: no get_by_id method on scores namespace")
+        score = scores_namespace.get_by_id(score_id=score_id)
         result = _sdk_object_to_python(score)
         if not result:
             raise LookupError(f"Score '{score_id}' not found")

--- a/langfuse_mcp/_compat.py
+++ b/langfuse_mcp/_compat.py
@@ -1,0 +1,210 @@
+"""Capability-based compatibility helpers for Langfuse SDK v3 and v4.
+
+The Langfuse Python SDK reorganized several namespaces between v3.x and v4.x:
+
+- ``langfuse.api.resources.<x>.types.<y>`` was flattened to ``langfuse.api.<x>.types.<y>``.
+- ``client.api.score_v_2`` was renamed to ``client.api.scores`` (with method
+  ``get`` -> ``get_many``).
+- ``client.api.observations.get(observation_id=...)`` was removed; the v1
+  legacy route at ``client.api.legacy.observations_v1`` remains page-based.
+- Several ``api.<resource>.create*`` and ``update*`` methods now take direct
+  kwargs instead of a Pydantic ``request=...`` model.
+
+This module exposes small, capability-based helpers — branching is done on
+*what the client actually exposes* rather than on a sniffed version string,
+which avoids the rot of version-coupled flags.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from collections.abc import Callable
+from typing import Any, Literal
+
+ObservationListMode = Literal["page", "cursor"]
+
+
+def resolve_request_model(category: str, module: str, name: str) -> Any:
+    """Import a request-model class from either v4 or v3 paths.
+
+    v4 path:  ``langfuse.api.<category>.types.<module>.<name>``
+    v3 path:  ``langfuse.api.resources.<category>.types.<module>.<name>``
+
+    Used only by the v3 ``request=<model>`` branch of the API; v4 callers pass
+    direct kwargs and never need to materialize the model. When neither path
+    exists (test stubs that mock ``langfuse`` as an empty module, partial SDK
+    installs) the function falls back to ``dict`` so callers can still
+    construct a request payload via ``Model(**kwargs)``. Only
+    ``ModuleNotFoundError`` from absent candidate paths is swallowed —
+    ``ImportError`` raised from inside an existing langfuse module (broken
+    install, transitive dep failure) is allowed to propagate so genuine
+    SDK breakage is not masked.
+    """
+    candidates = (
+        f"langfuse.api.{category}.types.{module}",
+        f"langfuse.api.resources.{category}.types.{module}",
+    )
+    for path in candidates:
+        try:
+            mod = importlib.import_module(path)
+        except ModuleNotFoundError as exc:
+            # Only swallow the specific case where this candidate path doesn't
+            # exist. ImportError (and other ModuleNotFoundError instances that
+            # name a *different* missing module) signal a real SDK problem.
+            if exc.name and (exc.name == path or path.startswith(f"{exc.name}.")):
+                continue
+            raise
+        if hasattr(mod, name):
+            return getattr(mod, name)
+    return dict
+
+
+def get_score_namespace(client: Any) -> Any | None:
+    """Return the score-resource namespace, preferring the v4 ``scores`` name.
+
+    v4: ``client.api.scores`` (methods: ``get_many``, ``get_by_id``).
+    v3: ``client.api.score_v_2`` (methods: ``get``, ``get_by_id``).
+    Returns ``None`` if neither is present.
+    """
+    api = getattr(client, "api", None)
+    if api is None:
+        return None
+    return getattr(api, "scores", None) or getattr(api, "score_v_2", None)
+
+
+def get_score_list_method(scores_namespace: Any) -> Any | None:
+    """Return the list-many callable on a score namespace.
+
+    v4 exposes ``get_many``; v3 exposes ``get`` (singular). Returns ``None``
+    when neither is present, so callers can degrade gracefully.
+    """
+    return getattr(scores_namespace, "get_many", None) or getattr(scores_namespace, "get", None)
+
+
+def get_observations_single_fetcher(client: Any) -> Callable[[str], Any] | None:
+    """Return a callable ``f(observation_id) -> observation`` or ``None``.
+
+    Precedence:
+    1. ``client.api.observations.get(observation_id=...)`` (v3)
+    2. ``client.api.legacy.observations_v1.get(observation_id)`` (v4 legacy
+       route — page-based, self-host safe)
+    3. ``client.fetch_observation(observation_id)`` (legacy v2 top-level)
+    """
+    api = getattr(client, "api", None)
+    if api is not None:
+        observations = getattr(api, "observations", None)
+        if observations is not None and hasattr(observations, "get"):
+            return lambda obs_id: observations.get(observation_id=obs_id)
+
+        legacy = getattr(api, "legacy", None)
+        legacy_v1 = getattr(legacy, "observations_v1", None) if legacy is not None else None
+        if legacy_v1 is not None and hasattr(legacy_v1, "get"):
+            return lambda obs_id: legacy_v1.get(obs_id)
+
+    if hasattr(client, "fetch_observation"):
+
+        def _via_top_level(obs_id: str) -> Any:
+            response = client.fetch_observation(obs_id)
+            return getattr(response, "data", response)
+
+        return _via_top_level
+
+    return None
+
+
+def get_observations_list_method(client: Any) -> tuple[Any, ObservationListMode] | None:
+    """Return (callable, mode) for listing observations.
+
+    Mode is one of:
+    - ``"page"``: callable accepts ``page=`` + ``limit=`` (v3 / v4 legacy_v1)
+    - ``"cursor"``: callable accepts ``cursor=`` + ``limit=`` (v4 observations_v2)
+
+    Precedence prefers page-capable routes so the MCP tool's ``page`` input
+    keeps its current semantics:
+    1. ``client.api.observations.get_many`` if it has a ``page`` param (v3)
+    2. ``client.api.legacy.observations_v1.get_many`` if it has a ``page`` param (v4 legacy)
+    3. ``client.api.observations.get_many`` cursor mode (v4 observations_v2)
+
+    Each candidate is verified by signature inspection — namespace presence
+    alone is not sufficient evidence of a page-capable contract.
+    """
+    api = getattr(client, "api", None)
+    if api is None:
+        return None
+
+    observations = getattr(api, "observations", None)
+    if observations is not None:
+        get_many = getattr(observations, "get_many", None)
+        if get_many is not None and method_has_param(get_many, "page") is True:
+            return get_many, "page"
+
+    legacy = getattr(api, "legacy", None)
+    legacy_v1 = getattr(legacy, "observations_v1", None) if legacy is not None else None
+    if legacy_v1 is not None:
+        legacy_get_many = getattr(legacy_v1, "get_many", None)
+        if legacy_get_many is not None and method_has_param(legacy_get_many, "page") is True:
+            return legacy_get_many, "page"
+
+    if observations is not None:
+        get_many = getattr(observations, "get_many", None)
+        if get_many is not None and method_has_param(get_many, "cursor") is True:
+            return get_many, "cursor"
+
+    return None
+
+
+def call_with_request_or_kwargs(
+    method: Callable[..., Any],
+    build_v3_request: Callable[[], Any],
+    /,
+    *,
+    path_kwargs: dict[str, Any] | None = None,
+    **body_kwargs: Any,
+) -> Any:
+    """Dispatch a write call across v3 (request=Pydantic) and v4 (direct kwargs).
+
+    v3 SDK call shape: ``method(**path_kwargs, request=<request_model>)``
+    v4 SDK call shape: ``method(**path_kwargs, **body_kwargs)``
+
+    ``path_kwargs`` carries identifiers that appear in BOTH call shapes
+    (``queue_id``, ``item_id``, ...). They are passed by keyword in both paths
+    so the dispatcher does not depend on positional binding through
+    ``functools.partial``, which mishandles keyword-only path params on
+    hypothetical SDK shapes.
+
+    ``body_kwargs`` are the v4 direct-kwargs payload; the v3 path receives them
+    via ``build_v3_request()`` instead.
+
+    Dispatch is decided by inspecting the method signature for a ``request``
+    parameter. ``method_has_param`` is tri-state — when signature inspection
+    fails the dispatcher raises rather than silently choosing the v4 branch.
+    """
+    has_request = method_has_param(method, "request")
+    path_kwargs = path_kwargs or {}
+    if has_request is True:
+        return method(**path_kwargs, request=build_v3_request())
+    if has_request is False:
+        return method(**path_kwargs, **body_kwargs)
+    raise RuntimeError(
+        f"Cannot determine call shape for {getattr(method, '__qualname__', method)!r}: "
+        f"signature inspection failed and dispatch requires a definite "
+        f"v3 (request=PydanticModel) vs v4 (direct kwargs) decision."
+    )
+
+
+def method_has_param(method: Callable[..., Any], name: str) -> bool | None:
+    """Return tri-state presence of parameter ``name`` on ``method``.
+
+    Returns:
+        - ``True`` — signature was inspected and ``name`` is a parameter
+        - ``False`` — signature was inspected and ``name`` is not a parameter
+        - ``None`` — signature could not be inspected (C extension, exotic
+          callable wrapper). Callers must treat this as *unknown*; conflating
+          it with ``False`` is the bug that hides v4-on-v3 dispatch errors.
+    """
+    try:
+        params = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return None
+    return name in params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 keywords = ["mcp", "langfuse", "observability", "tracing", "agents", "llm", "debugging"]
 dependencies = [
-    "langfuse>=3.11.2,<4.0.0",
+    "langfuse>=3.11.2,<5.0.0",
     "mcp[cli]>=1.6.0",
     "pydantic>=2.0.0",
     "cachetools>=5.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-python_functions = test_* 
+python_functions = test_*
+markers =
+    integration: live-API smoke tests requiring real Langfuse credentials (LANGFUSE_PUBLIC_KEY/SECRET_KEY); skipped by default

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -143,20 +143,17 @@ class FakeChatPrompt(FakePromptBase):
 
 @dataclass
 class FakePaginatedResponse:
-    """Minimal paginated response with data/meta attributes."""
+    """Minimal paginated response mirroring the real SDK shape (``data`` + ``meta``).
+
+    Real Langfuse SDK responses (``Traces``, ``PaginatedSessions``, ``ObservationsV2Response``,
+    etc.) carry only ``data`` and ``meta`` — no ``items`` or ``total`` attribute aliases. The
+    fake intentionally omits those aliases so the response-extraction logic in
+    ``_extract_items_from_response`` exercises the same ``.data + .meta`` code path as
+    against a real client.
+    """
 
     data: list[Any]
     meta: dict[str, Any]
-
-    @property
-    def items(self) -> list[Any]:
-        """Alias for data to match SDK response format."""
-        return self.data
-
-    @property
-    def total(self) -> int | None:
-        """Extract total from meta to match SDK response format."""
-        return self.meta.get("total")
 
 
 class _TraceAPI:
@@ -198,20 +195,28 @@ class _TraceAPI:
 
 
 class _ObservationsAPI:
-    """Fake implementation of observations resource client."""
+    """Fake implementation of the v3 observations resource client (page-based ``get_many``)."""
 
     def __init__(self, store: FakeDataStore) -> None:
         self._store = store
         self.last_get_many_kwargs: dict[str, Any] | None = None
         self.last_get_kwargs: dict[str, Any] | None = None
 
-    def get_many(self, **kwargs: Any) -> FakePaginatedResponse:
-        self.last_get_many_kwargs = kwargs
+    def get_many(
+        self,
+        *,
+        page: int | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> FakePaginatedResponse:
+        """Return observations using v3 page-based pagination."""
+        self.last_get_many_kwargs = {"page": page, "limit": limit, **kwargs}
         observations = list(self._store.observations.values())
         data = [obs.__dict__ for obs in observations]
         return FakePaginatedResponse(data=data, meta={"next_page": None, "total": len(data)})
 
     def get(self, observation_id: str, **kwargs: Any) -> dict[str, Any]:
+        """Return a single observation by id (v3 positional-or-keyword signature)."""
         self.last_get_kwargs = {"observation_id": observation_id, **kwargs}
         obs = self._store.observations.get(observation_id)
         return obs.__dict__ if obs else {}
@@ -556,6 +561,169 @@ class _ScoreV2API:
         return self._store.scores.get(score_id)
 
 
+class _AnnotationQueuesV4API:
+    """Fake v4 annotation_queues namespace: write methods take direct kwargs (no ``request=``)."""
+
+    def __init__(self, store: FakeDataStore) -> None:
+        """Bind the v4 annotation_queues namespace to the shared store."""
+        self._store = store
+        self.last_list_queues_kwargs: dict[str, Any] | None = None
+        self.last_create_queue_kwargs: dict[str, Any] | None = None
+        self.last_get_queue_kwargs: dict[str, Any] | None = None
+        self.last_list_items_kwargs: dict[str, Any] | None = None
+        self.last_get_item_kwargs: dict[str, Any] | None = None
+        self.last_create_item_kwargs: dict[str, Any] | None = None
+        self.last_update_item_kwargs: dict[str, Any] | None = None
+        self.last_create_assignment_kwargs: dict[str, Any] | None = None
+        self.last_delete_assignment_kwargs: dict[str, Any] | None = None
+
+    def list_queues(self, **kwargs: Any) -> FakePaginatedResponse:
+        """List annotation queues (unchanged across v3 and v4)."""
+        self.last_list_queues_kwargs = kwargs
+        queues = [q.__dict__ for q in self._store.annotation_queues.values()]
+        return FakePaginatedResponse(data=queues, meta={"next_page": None, "total": len(queues)})
+
+    def create_queue(
+        self,
+        *,
+        name: str,
+        score_config_ids: list[str],
+        description: str | None = None,
+    ) -> FakeAnnotationQueue:
+        """Create a queue using v4 direct-kwargs signature (no ``**kwargs`` — strict v4 contract).
+
+        Real v4 ``api.annotation_queues.create_queue`` rejects unexpected fields. The
+        fake omits ``**kwargs`` so production code that drifts back to the v3
+        ``request=`` shape (or sneaks in extra fields) raises a TypeError instead
+        of silently passing.
+        """
+        self.last_create_queue_kwargs = {"name": name, "score_config_ids": score_config_ids, "description": description}
+        now = datetime.now(timezone.utc)
+        queue = FakeAnnotationQueue(
+            id=f"queue_{len(self._store.annotation_queues) + 1}",
+            name=name,
+            description=description,
+            score_config_ids=list(score_config_ids),
+            created_at=now,
+        )
+        self._store.annotation_queues[queue.id] = queue
+        return queue
+
+    def get_queue(self, queue_id: str) -> Any:
+        """Return a queue by id."""
+        self.last_get_queue_kwargs = {"queue_id": queue_id}
+        return self._store.annotation_queues.get(queue_id)
+
+    def list_queue_items(
+        self,
+        queue_id: str,
+        *,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> FakePaginatedResponse:
+        """List items belonging to a queue."""
+        self.last_list_items_kwargs = {"queue_id": queue_id, "page": page, "limit": limit}
+        items = [item.__dict__ for item in self._store.annotation_queue_items.values() if item.queue_id == queue_id]
+        return FakePaginatedResponse(data=items, meta={"next_page": None, "total": len(items)})
+
+    def get_queue_item(self, queue_id: str, item_id: str) -> Any:
+        """Return a single queue item by ids."""
+        self.last_get_item_kwargs = {"queue_id": queue_id, "item_id": item_id}
+        item = self._store.annotation_queue_items.get(item_id)
+        return item if item and item.queue_id == queue_id else None
+
+    def create_queue_item(
+        self,
+        queue_id: str,
+        *,
+        object_id: str,
+        object_type: Any,
+        status: Any | None = None,
+    ) -> FakeAnnotationQueueItem:
+        """Create a queue item using v4 direct-kwargs signature (strict, no ``**kwargs``)."""
+        self.last_create_item_kwargs = {
+            "queue_id": queue_id,
+            "object_id": object_id,
+            "object_type": object_type,
+            "status": status,
+        }
+        now = datetime.now(timezone.utc)
+        item = FakeAnnotationQueueItem(
+            id=f"queue_item_{len(self._store.annotation_queue_items) + 1}",
+            queue_id=queue_id,
+            object_id=object_id,
+            object_type=object_type,
+            status=(status.value if hasattr(status, "value") else status) or "PENDING",
+            created_at=now,
+        )
+        self._store.annotation_queue_items[item.id] = item
+        return item
+
+    def update_queue_item(
+        self,
+        queue_id: str,
+        item_id: str,
+        *,
+        status: Any | None = None,
+    ) -> Any:
+        """Update a queue item's status using v4 direct-kwargs signature (strict)."""
+        self.last_update_item_kwargs = {"queue_id": queue_id, "item_id": item_id, "status": status}
+        item = self._store.annotation_queue_items.get(item_id)
+        if item and item.queue_id == queue_id:
+            item.status = status.value if hasattr(status, "value") else status
+            return item
+        return None
+
+    def delete_queue_item(self, queue_id: str, item_id: str) -> dict[str, Any]:
+        """Delete a queue item by id."""
+        item = self._store.annotation_queue_items.get(item_id)
+        if item and item.queue_id == queue_id:
+            del self._store.annotation_queue_items[item_id]
+        return {"success": True}
+
+    def create_queue_assignment(self, queue_id: str, *, user_id: str) -> dict[str, Any]:
+        """Create a queue assignment using v4 direct-kwargs signature (strict)."""
+        self.last_create_assignment_kwargs = {"queue_id": queue_id, "user_id": user_id}
+        self._store.queue_assignments.setdefault(queue_id, set()).add(user_id)
+        return {"success": True, "queue_id": queue_id, "user_id": user_id}
+
+    def delete_queue_assignment(self, queue_id: str, *, user_id: str) -> dict[str, Any]:
+        """Delete a queue assignment using v4 direct-kwargs signature (strict)."""
+        self.last_delete_assignment_kwargs = {"queue_id": queue_id, "user_id": user_id}
+        self._store.queue_assignments.setdefault(queue_id, set()).discard(user_id)
+        return {"success": True, "queue_id": queue_id, "user_id": user_id}
+
+
+class _ScoresV4API:
+    """Fake v4 scores namespace: ``get_many`` replaces v3's ``get``."""
+
+    def __init__(self, store: FakeDataStore) -> None:
+        """Bind the v4 scores namespace to the shared store."""
+        self._store = store
+        self.last_get_many_kwargs: dict[str, Any] | None = None
+        self.last_get_by_id_kwargs: dict[str, Any] | None = None
+
+    def get_many(self, **kwargs: Any) -> FakePaginatedResponse:
+        """List scores using v4 ``scores.get_many`` semantics (page-based)."""
+        self.last_get_many_kwargs = kwargs
+        scores = [s.__dict__ for s in self._store.scores.values()]
+        user_id = kwargs.get("user_id")
+        if user_id:
+            scores = [s for s in scores if s.get("user_id") == user_id]
+        queue_id = kwargs.get("queue_id")
+        if queue_id:
+            scores = [s for s in scores if s.get("queue_id") == queue_id]
+        trace_id = kwargs.get("trace_id")
+        if trace_id:
+            scores = [s for s in scores if s.get("trace_id") == trace_id]
+        return FakePaginatedResponse(data=scores, meta={"next_page": None, "total": len(scores)})
+
+    def get_by_id(self, *, score_id: str, **kwargs: Any) -> Any:
+        """Return a score by id (v4 keyword-only signature)."""
+        self.last_get_by_id_kwargs = {"score_id": score_id, **kwargs}
+        return self._store.scores.get(score_id)
+
+
 class FakeAPI:
     """Aggregate object exposed via FakeLangfuse.api."""
 
@@ -569,6 +737,92 @@ class FakeAPI:
         self.dataset_items = _DatasetItemsAPI(store)
         self.annotation_queues = _AnnotationQueuesAPI(store)
         self.score_v_2 = _ScoreV2API(store)
+
+
+class _ObservationsV4API:
+    """Fake v4 observations namespace: ``get_many`` is cursor-only and ``get`` is absent."""
+
+    def __init__(self, store: FakeDataStore) -> None:
+        """Bind the fake v4 observations namespace to the shared store."""
+        self._store = store
+        self.last_get_many_kwargs: dict[str, Any] | None = None
+
+    def get_many(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> FakePaginatedResponse:
+        """Return observations using cursor-based pagination (v4 ObservationsV2)."""
+        self.last_get_many_kwargs = {"cursor": cursor, "limit": limit, **kwargs}
+        observations = list(self._store.observations.values())
+        data = [obs.__dict__ for obs in observations]
+        # v4 ObservationsV2Meta carries only ``cursor``; ``None`` means no further pages.
+        return FakePaginatedResponse(data=data, meta={"cursor": None})
+
+
+class _LegacyObservationsV1API:
+    """Fake v4 ``api.legacy.observations_v1`` namespace exposing the page-based v1 surface."""
+
+    def __init__(self, store: FakeDataStore) -> None:
+        """Bind the legacy v1 observations namespace to the shared store."""
+        self._store = store
+        self.last_get_kwargs: dict[str, Any] | None = None
+        self.last_get_many_kwargs: dict[str, Any] | None = None
+
+    def get(self, observation_id: str, **kwargs: Any) -> dict[str, Any]:
+        """Return a single observation by id (positional, matching v4 legacy signature)."""
+        self.last_get_kwargs = {"observation_id": observation_id, **kwargs}
+        obs = self._store.observations.get(observation_id)
+        return obs.__dict__ if obs else {}
+
+    def get_many(
+        self,
+        *,
+        page: int | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> FakePaginatedResponse:
+        """Return observations using page-based pagination via the legacy v1 endpoint."""
+        self.last_get_many_kwargs = {"page": page, "limit": limit, **kwargs}
+        observations = list(self._store.observations.values())
+        data = [obs.__dict__ for obs in observations]
+        return FakePaginatedResponse(data=data, meta={"next_page": None, "total": len(data)})
+
+
+class _LegacyAPI:
+    """Fake v4 ``api.legacy`` namespace housing the v1 fallbacks."""
+
+    def __init__(self, store: FakeDataStore) -> None:
+        """Wire the legacy v1 namespaces to the shared store."""
+        self.observations_v1 = _LegacyObservationsV1API(store)
+
+
+class FakeAPIV4:
+    """Aggregate object exposed via FakeLangfuseV4.api — v4 surface only.
+
+    Differences vs. v3 (``FakeAPI``):
+    - No ``score_v_2``; scores resource is renamed to ``scores`` with ``get_many``.
+    - ``observations.get`` is absent; ``observations.get_many`` is cursor-only.
+    - ``api.legacy.observations_v1`` exposes the page-based v1 fallback.
+    - Annotation queue write methods take direct kwargs (no ``request=``).
+    - ``api.datasets`` / ``api.dataset_items`` are intentionally not wired —
+      production code only calls them through the top-level
+      ``Langfuse.create_dataset`` / ``create_dataset_item`` shortcuts that v3
+      and v4 both expose, so the api-level surface here would be unused.
+    """
+
+    def __init__(self, store: FakeDataStore) -> None:
+        """Wire the v4-shaped API resources to the shared store."""
+        self.trace = _TraceAPI(store)
+        self.observations = _ObservationsV4API(store)
+        self.sessions = _SessionsAPI(store)
+        self.prompts = _PromptsAPI(store)
+        self.scores = _ScoresV4API(store)
+        self.annotation_queues = _AnnotationQueuesV4API(store)
+        # datasets/dataset_items are filled in by S4.
+        self.legacy = _LegacyAPI(store)
 
 
 class FakeDataStore:
@@ -819,6 +1073,34 @@ class FakeLangfuse:
     def shutdown(self) -> None:  # pragma: no cover - compatibility shim
         """Provide the Langfuse SDK shutdown hook by delegating to close()."""
         self.close()
+
+
+class FakeLangfuseV4:
+    """Langfuse client double exposing the v4 API surface.
+
+    Compared to ``FakeLangfuse`` (v3 shape):
+    - ``api`` is a ``FakeAPIV4`` (no ``score_v_2``, cursor-only observations,
+      legacy fallbacks under ``api.legacy``, kwargs-style annotation queue writes).
+    - The top-level ``fetch_observation`` shim is intentionally absent (v4 removed it).
+    - The top-level ``create_dataset`` / ``create_dataset_item`` shortcuts are also
+      absent here so dataset tests stay scoped to ``FakeLangfuse``; both real v3 and
+      v4 expose them, but exercising the v4 dataset path through this fake would just
+      re-test the unchanged shortcut shim.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the fake v4 client with in-memory storage and v4 API facade."""
+        self._store = FakeDataStore()
+        self.api = FakeAPIV4(self._store)
+        self.closed = False
+
+    def flush(self) -> None:  # pragma: no cover - compatibility shim
+        """Match the v4 ``Langfuse.flush`` no-op contract."""
+        return None
+
+    def shutdown(self) -> None:  # pragma: no cover - compatibility shim
+        """Match the v4 ``Langfuse.shutdown`` contract by marking the client closed."""
+        self.closed = True
 
 
 class FakeContext:

--- a/tests/test_annotation_queues_scores.py
+++ b/tests/test_annotation_queues_scores.py
@@ -7,14 +7,43 @@ from datetime import datetime, timezone
 
 import pytest
 
-from tests.fakes import FakeContext, FakeLangfuse
+from tests.fakes import FakeContext, FakeLangfuse, FakeLangfuseV4
 
 
 def _state(tmp_path):
-    """Create MCP state backed by fake Langfuse client."""
+    """Create MCP state backed by the v3-shaped fake Langfuse client."""
     from langfuse_mcp.__main__ import MCPState
 
     return MCPState(langfuse_client=FakeLangfuse(), dump_dir=str(tmp_path))
+
+
+@pytest.fixture(params=["v3", "v4"], ids=["v3", "v4"])
+def score_state(request, tmp_path):
+    """Return MCP state parametrized across v3 and v4 fake client shapes for score tests."""
+    from langfuse_mcp.__main__ import MCPState
+
+    client = FakeLangfuse() if request.param == "v3" else FakeLangfuseV4()
+    return MCPState(langfuse_client=client, dump_dir=str(tmp_path))
+
+
+@pytest.fixture(params=["v3", "v4"], ids=["v3", "v4"])
+def annotation_queue_state(request, tmp_path):
+    """Return MCP state parametrized across v3 and v4 fake client shapes for annotation queue tests."""
+    from langfuse_mcp.__main__ import MCPState
+
+    client = FakeLangfuse() if request.param == "v3" else FakeLangfuseV4()
+    return MCPState(langfuse_client=client, dump_dir=str(tmp_path))
+
+
+def _scores_namespace(client):
+    """Return the scores namespace (v4 ``scores`` or v3 ``score_v_2``)."""
+    return getattr(client.api, "scores", None) or client.api.score_v_2
+
+
+def _last_list_score_kwargs(client) -> dict | None:
+    """Return whichever fake recorded the last list call (v3 ``last_get_kwargs`` or v4 ``last_get_many_kwargs``)."""
+    namespace = _scores_namespace(client)
+    return getattr(namespace, "last_get_many_kwargs", None) or getattr(namespace, "last_get_kwargs", None)
 
 
 def test_annotation_queue_tools_registered_in_groups():
@@ -29,8 +58,8 @@ def test_annotation_queue_tools_registered_in_groups():
     assert "delete_annotation_queue_assignment" in WRITE_TOOLS
 
 
-def test_annotation_queue_crud_and_assignment(tmp_path):
-    """Annotation queue create/read/update and assignment flow should work."""
+def test_annotation_queue_crud_and_assignment(annotation_queue_state):
+    """Annotation queue create/read/update and assignment flow should work on both v3 and v4 clients."""
     from langfuse_mcp.__main__ import (
         create_annotation_queue,
         create_annotation_queue_assignment,
@@ -43,7 +72,7 @@ def test_annotation_queue_crud_and_assignment(tmp_path):
         update_annotation_queue_item,
     )
 
-    state = _state(tmp_path)
+    state = annotation_queue_state
     ctx = FakeContext(state)
 
     created = asyncio.run(
@@ -90,8 +119,22 @@ def test_annotation_queue_crud_and_assignment(tmp_path):
     assert unassigned["metadata"]["deleted"] is True
 
 
-def test_delete_annotation_queue_item(tmp_path):
-    """delete_annotation_queue_item should remove the item from queue lookups."""
+def test_create_annotation_queue_omits_score_config_ids_as_empty_list(annotation_queue_state):
+    """Omitted ``score_config_ids`` must reach the SDK as ``[]`` (real v3 + v4 reject ``None``)."""
+    from langfuse_mcp.__main__ import create_annotation_queue
+
+    state = annotation_queue_state
+    ctx = FakeContext(state)
+
+    result = asyncio.run(create_annotation_queue(ctx, name="bare-queue"))
+    assert result["metadata"]["created"] is True
+
+    persisted = next(q for q in state.langfuse_client._store.annotation_queues.values() if q.name == "bare-queue")
+    assert persisted.score_config_ids == []
+
+
+def test_delete_annotation_queue_item(annotation_queue_state):
+    """delete_annotation_queue_item should remove the item from queue lookups on both v3 and v4 clients."""
     from langfuse_mcp.__main__ import (
         create_annotation_queue,
         create_annotation_queue_item,
@@ -99,7 +142,7 @@ def test_delete_annotation_queue_item(tmp_path):
         get_annotation_queue_item,
     )
 
-    state = _state(tmp_path)
+    state = annotation_queue_state
     ctx = FakeContext(state)
 
     queue = asyncio.run(create_annotation_queue(ctx, name="delete-queue"))
@@ -116,12 +159,11 @@ def test_delete_annotation_queue_item(tmp_path):
         asyncio.run(get_annotation_queue_item(ctx, queue_id=queue_id, item_id=item_id))
 
 
-def test_score_v2_tools(tmp_path):
-    """Score v2 list and get-by-id tools should return seeded score data."""
+def test_score_v2_tools(score_state):
+    """Score list and get-by-id tools should return seeded score data on both v3 and v4 clients."""
     from langfuse_mcp.__main__ import get_score_v2, list_scores_v2
 
-    state = _state(tmp_path)
-    ctx = FakeContext(state)
+    ctx = FakeContext(score_state)
 
     listed = asyncio.run(list_scores_v2(ctx, page=1, limit=10, user_id="user_1"))
     assert listed["metadata"]["item_count"] >= 1
@@ -131,12 +173,11 @@ def test_score_v2_tools(tmp_path):
     assert score["data"]["id"] == score_id
 
 
-def test_list_scores_v2_coerces_iso_timestamps_and_float_value(tmp_path):
-    """ISO timestamps should be coerced to datetime and value should be float."""
+def test_list_scores_v2_coerces_iso_timestamps_and_float_value(score_state):
+    """ISO timestamps should be coerced to datetime and value should be float — on both v3/v4 clients."""
     from langfuse_mcp.__main__ import list_scores_v2
 
-    state = _state(tmp_path)
-    ctx = FakeContext(state)
+    ctx = FakeContext(score_state)
 
     result = asyncio.run(
         list_scores_v2(
@@ -150,7 +191,7 @@ def test_list_scores_v2_coerces_iso_timestamps_and_float_value(tmp_path):
     )
     assert result["metadata"]["item_count"] >= 1
 
-    passed_kwargs = state.langfuse_client.api.score_v_2.last_get_kwargs
+    passed_kwargs = _last_list_score_kwargs(score_state.langfuse_client)
     assert passed_kwargs is not None
     assert isinstance(passed_kwargs.get("from_timestamp"), datetime)
     assert isinstance(passed_kwargs.get("to_timestamp"), datetime)
@@ -170,46 +211,43 @@ def test_list_scores_v2_rejects_invalid_timestamp(tmp_path):
         asyncio.run(list_scores_v2(ctx, from_timestamp="not-a-timestamp"))
 
 
-def test_list_scores_v2_accepts_datetime_objects(tmp_path):
-    """Datetime inputs should pass through to score_v_2.get unchanged."""
+def test_list_scores_v2_accepts_datetime_objects(score_state):
+    """Datetime inputs should pass through unchanged on both v3 score_v_2 and v4 scores."""
     from langfuse_mcp.__main__ import list_scores_v2
 
-    state = _state(tmp_path)
-    ctx = FakeContext(state)
+    ctx = FakeContext(score_state)
 
     start = datetime(2026, 3, 30, 10, 11, 12, tzinfo=timezone.utc)
     end = datetime(2026, 3, 30, 11, 11, 12, tzinfo=timezone.utc)
     asyncio.run(list_scores_v2(ctx, from_timestamp=start, to_timestamp=end, value=1.0))
 
-    passed_kwargs = state.langfuse_client.api.score_v_2.last_get_kwargs
+    passed_kwargs = _last_list_score_kwargs(score_state.langfuse_client)
     assert passed_kwargs is not None
     assert passed_kwargs["from_timestamp"] == start
     assert passed_kwargs["to_timestamp"] == end
 
 
-def test_list_scores_v2_keeps_zero_float_filter(tmp_path):
-    """A valid value=0.0 filter should not be dropped from API kwargs."""
+def test_list_scores_v2_keeps_zero_float_filter(score_state):
+    """A valid value=0.0 filter should not be dropped from API kwargs (v3 and v4)."""
     from langfuse_mcp.__main__ import list_scores_v2
 
-    state = _state(tmp_path)
-    ctx = FakeContext(state)
+    ctx = FakeContext(score_state)
 
     asyncio.run(list_scores_v2(ctx, value=0.0))
-    passed_kwargs = state.langfuse_client.api.score_v_2.last_get_kwargs
+    passed_kwargs = _last_list_score_kwargs(score_state.langfuse_client)
     assert passed_kwargs is not None
     assert "value" in passed_kwargs
     assert passed_kwargs["value"] == 0.0
 
 
-def test_list_scores_v2_supports_trace_id_filter(tmp_path):
-    """trace_id filter should be forwarded to the score v2 client."""
+def test_list_scores_v2_supports_trace_id_filter(score_state):
+    """trace_id filter should be forwarded to the score client on both v3 and v4."""
     from langfuse_mcp.__main__ import list_scores_v2
 
-    state = _state(tmp_path)
-    ctx = FakeContext(state)
+    ctx = FakeContext(score_state)
 
     result = asyncio.run(list_scores_v2(ctx, trace_id="trace_1"))
     assert result["metadata"]["item_count"] >= 1
-    passed_kwargs = state.langfuse_client.api.score_v_2.last_get_kwargs
+    passed_kwargs = _last_list_score_kwargs(score_state.langfuse_client)
     assert passed_kwargs is not None
     assert passed_kwargs["trace_id"] == "trace_1"

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,435 @@
+"""Unit tests for langfuse_mcp._compat capability helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from langfuse_mcp._compat import (
+    call_with_request_or_kwargs,
+    get_observations_list_method,
+    get_observations_single_fetcher,
+    get_score_list_method,
+    get_score_namespace,
+    method_has_param,
+    resolve_request_model,
+)
+
+
+def _install_fake_module(monkeypatch: pytest.MonkeyPatch, name: str, **attrs: Any) -> None:
+    """Register a fake module under ``name`` and stash any provided attributes."""
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+# ---------- resolve_request_model ----------
+
+
+def test_resolve_request_model_prefers_v4_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolver should pick the flattened v4 path before falling back to v3."""
+
+    class V4Request:
+        pass
+
+    _install_fake_module(monkeypatch, "langfuse")
+    _install_fake_module(monkeypatch, "langfuse.api")
+    _install_fake_module(monkeypatch, "langfuse.api.datasets")
+    _install_fake_module(monkeypatch, "langfuse.api.datasets.types")
+    _install_fake_module(
+        monkeypatch,
+        "langfuse.api.datasets.types.create_dataset_request",
+        CreateDatasetRequest=V4Request,
+    )
+    resolved = resolve_request_model("datasets", "create_dataset_request", "CreateDatasetRequest")
+    assert resolved is V4Request
+
+
+def test_resolve_request_model_falls_back_to_v3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolver should locate the v3 ``langfuse.api.resources.*`` path when v4 is absent."""
+
+    class V3Request:
+        pass
+
+    _install_fake_module(monkeypatch, "langfuse")
+    _install_fake_module(monkeypatch, "langfuse.api")
+    _install_fake_module(monkeypatch, "langfuse.api.resources")
+    _install_fake_module(monkeypatch, "langfuse.api.resources.datasets")
+    _install_fake_module(monkeypatch, "langfuse.api.resources.datasets.types")
+    _install_fake_module(
+        monkeypatch,
+        "langfuse.api.resources.datasets.types.create_dataset_request",
+        CreateDatasetRequest=V3Request,
+    )
+    resolved = resolve_request_model("datasets", "create_dataset_request", "CreateDatasetRequest")
+    assert resolved is V3Request
+
+
+def test_resolve_request_model_falls_back_to_dict_when_neither_path_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolver should fall back to ``dict`` so ``Model(**kwargs)`` still constructs a payload."""
+    monkeypatch.setitem(sys.modules, "langfuse", types.ModuleType("langfuse"))
+    resolved = resolve_request_model("datasets", "missing_module", "MissingModel")
+    assert resolved is dict
+    payload = resolved(name="alpha", description="bravo")
+    assert payload == {"name": "alpha", "description": "bravo"}
+
+
+# ---------- get_score_namespace / get_score_list_method ----------
+
+
+def test_get_score_namespace_prefers_v4_scores() -> None:
+    """Helper should prefer ``api.scores`` (v4) when both namespaces are present."""
+    v4_scores = SimpleNamespace(get_many=lambda **_: None, get_by_id=lambda **_: None)
+    v3_scores = SimpleNamespace(get=lambda **_: None, get_by_id=lambda **_: None)
+    client = SimpleNamespace(api=SimpleNamespace(scores=v4_scores, score_v_2=v3_scores))
+    assert get_score_namespace(client) is v4_scores
+
+
+def test_get_score_namespace_falls_back_to_v3() -> None:
+    """Helper should return ``api.score_v_2`` when only the v3 namespace exists."""
+    v3_scores = SimpleNamespace(get=lambda **_: None, get_by_id=lambda **_: None)
+    client = SimpleNamespace(api=SimpleNamespace(score_v_2=v3_scores))
+    assert get_score_namespace(client) is v3_scores
+
+
+def test_get_score_namespace_returns_none_when_missing() -> None:
+    """Helper should yield ``None`` when neither score namespace is exposed."""
+    client = SimpleNamespace(api=SimpleNamespace())
+    assert get_score_namespace(client) is None
+
+
+def test_get_score_list_method_prefers_get_many_for_v4() -> None:
+    """List-method helper should prefer ``get_many`` (v4 plural)."""
+    sentinel_v4 = lambda **_: None  # noqa: E731
+    sentinel_v3 = lambda **_: None  # noqa: E731
+    namespace = SimpleNamespace(get_many=sentinel_v4, get=sentinel_v3)
+    assert get_score_list_method(namespace) is sentinel_v4
+
+
+def test_get_score_list_method_falls_back_to_get_for_v3() -> None:
+    """List-method helper should fall back to ``get`` for v3-shaped namespaces."""
+    sentinel_v3 = lambda **_: None  # noqa: E731
+    namespace = SimpleNamespace(get=sentinel_v3)
+    assert get_score_list_method(namespace) is sentinel_v3
+
+
+# ---------- get_observations_single_fetcher ----------
+
+
+def test_observations_single_fetcher_prefers_v3_get() -> None:
+    """Single-fetcher should select ``api.observations.get`` first when present."""
+    captured: dict[str, Any] = {}
+
+    def v3_get(*, observation_id: str) -> str:
+        captured["called"] = observation_id
+        return "v3"
+
+    api = SimpleNamespace(observations=SimpleNamespace(get=v3_get))
+    client = SimpleNamespace(api=api)
+    fetcher = get_observations_single_fetcher(client)
+    assert fetcher is not None
+    assert fetcher("obs1") == "v3"
+    assert captured["called"] == "obs1"
+
+
+def test_observations_single_fetcher_uses_legacy_when_v3_absent() -> None:
+    """Single-fetcher should drop to ``api.legacy.observations_v1.get`` on v4 SDKs."""
+    captured: dict[str, Any] = {}
+
+    def legacy_get(observation_id: str) -> str:
+        captured["called"] = observation_id
+        return "legacy"
+
+    legacy = SimpleNamespace(observations_v1=SimpleNamespace(get=legacy_get))
+    # observations namespace exists but has no .get (v4 with cursor get_many only)
+    observations = SimpleNamespace(get_many=lambda **_: None)
+    api = SimpleNamespace(observations=observations, legacy=legacy)
+    client = SimpleNamespace(api=api)
+    fetcher = get_observations_single_fetcher(client)
+    assert fetcher is not None
+    assert fetcher("obs2") == "legacy"
+    assert captured["called"] == "obs2"
+
+
+def test_observations_single_fetcher_uses_top_level_fallback() -> None:
+    """Single-fetcher should accept the top-level ``client.fetch_observation`` shim."""
+
+    def fetch_observation(obs_id: str) -> str:
+        return f"top:{obs_id}"
+
+    client = SimpleNamespace(api=SimpleNamespace(), fetch_observation=fetch_observation)
+    fetcher = get_observations_single_fetcher(client)
+    assert fetcher is not None
+    assert fetcher("obs3") == "top:obs3"
+
+
+def test_observations_single_fetcher_unwraps_top_level_envelope() -> None:
+    """Top-level ``fetch_observation`` envelopes (``.data``) must be unwrapped to match the v3/legacy contract."""
+    payload = {"id": "obs9", "name": "envelope"}
+
+    def fetch_observation(obs_id: str) -> SimpleNamespace:
+        return SimpleNamespace(data=payload)
+
+    client = SimpleNamespace(api=SimpleNamespace(), fetch_observation=fetch_observation)
+    fetcher = get_observations_single_fetcher(client)
+    assert fetcher is not None
+    assert fetcher("obs9") is payload
+
+
+def test_observations_single_fetcher_returns_none_when_unsupported() -> None:
+    """Single-fetcher should yield ``None`` when no observation route is exposed."""
+    client = SimpleNamespace(api=SimpleNamespace())
+    assert get_observations_single_fetcher(client) is None
+
+
+# ---------- get_observations_list_method ----------
+
+
+def test_observations_list_prefers_v3_page_get_many() -> None:
+    """List-method helper should pick the page-based ``api.observations.get_many`` first."""
+
+    def v3_get_many(*, page: int | None = None, limit: int | None = None) -> dict:
+        return {"data": [], "page": page, "limit": limit}
+
+    api = SimpleNamespace(observations=SimpleNamespace(get_many=v3_get_many))
+    client = SimpleNamespace(api=api)
+    method, mode = get_observations_list_method(client)  # type: ignore[misc]
+    assert method is v3_get_many
+    assert mode == "page"
+
+
+def test_observations_list_falls_back_to_legacy_v1() -> None:
+    """List-method helper should jump to ``legacy.observations_v1`` when only cursor v2 is present."""
+
+    def cursor_only(*, cursor: str | None = None, limit: int | None = None) -> dict:
+        return {}
+
+    def legacy_page(*, page: int | None = None, limit: int | None = None) -> dict:
+        return {}
+
+    api = SimpleNamespace(
+        observations=SimpleNamespace(get_many=cursor_only),
+        legacy=SimpleNamespace(observations_v1=SimpleNamespace(get_many=legacy_page)),
+    )
+    client = SimpleNamespace(api=api)
+    method, mode = get_observations_list_method(client)  # type: ignore[misc]
+    assert method is legacy_page
+    assert mode == "page"
+
+
+def test_observations_list_uses_cursor_when_no_page_route() -> None:
+    """List-method helper should fall through to cursor mode when nothing else exists."""
+
+    def cursor_only(*, cursor: str | None = None, limit: int | None = None) -> dict:
+        return {}
+
+    api = SimpleNamespace(observations=SimpleNamespace(get_many=cursor_only))
+    client = SimpleNamespace(api=api)
+    method, mode = get_observations_list_method(client)  # type: ignore[misc]
+    assert method is cursor_only
+    assert mode == "cursor"
+
+
+def test_observations_list_returns_none_when_unsupported() -> None:
+    """List-method helper should return ``None`` when no observation route is found."""
+    client = SimpleNamespace(api=SimpleNamespace())
+    assert get_observations_list_method(client) is None
+
+
+# ---------- call_with_request_or_kwargs ----------
+
+
+def test_dispatcher_uses_request_when_method_accepts_it() -> None:
+    """Dispatcher should call ``method(request=...)`` when the v3 signature is present."""
+    captured: dict[str, Any] = {}
+
+    def v3_method(*, request: Any) -> str:
+        captured["request"] = request
+        return "v3"
+
+    class _Req:
+        def __init__(self, **kw: Any) -> None:
+            self.__dict__.update(kw)
+
+    result = call_with_request_or_kwargs(
+        v3_method,
+        lambda: _Req(name="alpha"),
+        name="alpha",
+    )
+    assert result == "v3"
+    assert captured["request"].name == "alpha"
+
+
+def test_dispatcher_uses_kwargs_when_method_lacks_request() -> None:
+    """Dispatcher should switch to direct kwargs against v4 signatures."""
+    captured: dict[str, Any] = {}
+
+    def v4_method(*, name: str) -> str:
+        captured["name"] = name
+        return "v4"
+
+    result = call_with_request_or_kwargs(
+        v4_method,
+        lambda: pytest.fail("v3 builder should not run"),  # type: ignore[arg-type]
+        name="beta",
+    )
+    assert result == "v4"
+    assert captured["name"] == "beta"
+
+
+def test_dispatcher_threads_path_kwargs_to_v3_branch() -> None:
+    """Path identifiers should pass through to the v3 ``request=`` branch alongside the request body."""
+    captured: dict[str, Any] = {}
+
+    def v3_method(*, queue_id: str, item_id: str, request: Any) -> str:
+        captured["queue_id"] = queue_id
+        captured["item_id"] = item_id
+        captured["request"] = request
+        return "v3"
+
+    class _Req:
+        def __init__(self, **kw: Any) -> None:
+            self.__dict__.update(kw)
+
+    result = call_with_request_or_kwargs(
+        v3_method,
+        lambda: _Req(status="OPEN"),
+        path_kwargs={"queue_id": "Q1", "item_id": "I1"},
+        status="OPEN",
+    )
+    assert result == "v3"
+    assert captured["queue_id"] == "Q1"
+    assert captured["item_id"] == "I1"
+    assert captured["request"].status == "OPEN"
+
+
+def test_dispatcher_threads_path_kwargs_to_v4_branch() -> None:
+    """Path identifiers should pass through to the v4 direct-kwargs branch alongside body kwargs."""
+    captured: dict[str, Any] = {}
+
+    def v4_method(*, queue_id: str, item_id: str, status: str) -> str:
+        captured["queue_id"] = queue_id
+        captured["item_id"] = item_id
+        captured["status"] = status
+        return "v4"
+
+    result = call_with_request_or_kwargs(
+        v4_method,
+        lambda: pytest.fail("v3 builder should not run"),  # type: ignore[arg-type]
+        path_kwargs={"queue_id": "Q1", "item_id": "I1"},
+        status="OPEN",
+    )
+    assert result == "v4"
+    assert captured["queue_id"] == "Q1"
+    assert captured["item_id"] == "I1"
+    assert captured["status"] == "OPEN"
+
+
+def test_dispatcher_raises_on_unknown_method_shape() -> None:
+    """Dispatcher must raise rather than silently default to v4 when shape is unknown."""
+
+    class _Unsignable:
+        """Callable wrapper whose signature ``inspect.signature`` cannot resolve."""
+
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - never invoked
+            raise AssertionError("dispatcher should refuse to call this")
+
+        @property
+        def __signature__(self) -> Any:
+            raise ValueError("signature unresolvable")
+
+    with pytest.raises(RuntimeError, match="signature inspection failed"):
+        call_with_request_or_kwargs(_Unsignable(), lambda: None, name="x")
+
+
+def test_method_has_param_tri_state_returns_none_on_failure() -> None:
+    """``method_has_param`` must return ``None`` (not ``False``) when introspection fails."""
+
+    class _Unsignable:
+        @property
+        def __signature__(self) -> Any:
+            raise ValueError("unresolvable")
+
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover
+            return None
+
+    assert method_has_param(_Unsignable(), "request") is None
+
+
+def test_method_has_param_returns_true_for_present_param() -> None:
+    """Sanity check that ``method_has_param`` still returns explicit ``True`` for present params."""
+
+    def has_request(*, request: Any) -> None:
+        return None
+
+    assert method_has_param(has_request, "request") is True
+
+
+def test_method_has_param_returns_false_for_absent_param() -> None:
+    """Sanity check that ``method_has_param`` returns explicit ``False`` for absent params."""
+
+    def no_request(*, name: str) -> None:
+        return None
+
+    assert method_has_param(no_request, "request") is False
+
+
+def test_observations_list_skips_legacy_v1_when_page_param_absent() -> None:
+    """A legacy ``observations_v1.get_many`` lacking a ``page`` param must not be selected."""
+
+    def cursor_only_obs(*, cursor: str | None = None, limit: int | None = None) -> dict:
+        return {}
+
+    def cursor_only_legacy(*, cursor: str | None = None, limit: int | None = None) -> dict:
+        return {}
+
+    api = SimpleNamespace(
+        observations=SimpleNamespace(get_many=cursor_only_obs),
+        legacy=SimpleNamespace(observations_v1=SimpleNamespace(get_many=cursor_only_legacy)),
+    )
+    client = SimpleNamespace(api=api)
+    # legacy doesn't expose `page`, so the helper must fall through to cursor mode
+    # rather than blindly trusting the legacy namespace's existence.
+    method, mode = get_observations_list_method(client)  # type: ignore[misc]
+    assert mode == "cursor"
+    assert method is cursor_only_obs
+
+
+def test_resolve_request_model_propagates_unrelated_module_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Broken transitive imports inside an existing langfuse module must not be silently swallowed."""
+    broken_path = "langfuse.api.datasets.types.create_dataset_request"
+
+    def faulting_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == broken_path:
+            raise ModuleNotFoundError("No module named 'somethirdpartydep'", name="somethirdpartydep")
+        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+    monkeypatch.setattr("langfuse_mcp._compat.importlib.import_module", faulting_import)
+    with pytest.raises(ModuleNotFoundError, match="somethirdpartydep"):
+        resolve_request_model("datasets", "create_dataset_request", "CreateDatasetRequest")
+
+
+# ---------- _extract_items_from_response (response.data + meta) ----------
+
+
+def test_extract_items_preserves_meta_on_data_branch() -> None:
+    """Response with ``.data`` + ``.meta`` should expose pagination, not collapse to ``{}``."""
+    from langfuse_mcp.__main__ import _extract_items_from_response
+
+    class CursorMeta:
+        def __init__(self) -> None:
+            self.cursor = "abc123"
+
+    class CursorResponse:
+        def __init__(self) -> None:
+            self.data = ["a", "b"]
+            self.meta = CursorMeta()
+
+    items, pagination = _extract_items_from_response(CursorResponse())
+    assert items == ["a", "b"]
+    assert pagination.get("cursor") == "abc123"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,15 +7,46 @@ import json
 
 import pytest
 
-from tests.fakes import FakeContext, FakeLangfuse
+from tests.fakes import FakeContext, FakeLangfuse, FakeLangfuseV4
 
 
 @pytest.fixture()
 def state(tmp_path):
-    """Return an MCPState instance using the fake client."""
+    """Return an MCPState instance using the v3-shaped fake client."""
     from langfuse_mcp.__main__ import MCPState
 
     return MCPState(langfuse_client=FakeLangfuse(), dump_dir=str(tmp_path))
+
+
+@pytest.fixture(params=["v3", "v4"], ids=["v3", "v4"])
+def observation_state(request, tmp_path):
+    """Return an MCPState parametrized across the v3 and v4 fake client shapes.
+
+    Tests using this fixture run twice — once against ``FakeLangfuse`` (v3 surface
+    with ``api.observations.{get,get_many}``) and once against ``FakeLangfuseV4``
+    (v4 surface with cursor-only ``api.observations.get_many`` and
+    ``api.legacy.observations_v1`` page-based fallbacks).
+    """
+    from langfuse_mcp.__main__ import MCPState
+
+    client = FakeLangfuse() if request.param == "v3" else FakeLangfuseV4()
+    return MCPState(langfuse_client=client, dump_dir=str(tmp_path))
+
+
+def _observation_list_fake(client):
+    """Return whichever fake namespace recorded the last list call (v3 vs v4 legacy)."""
+    legacy = getattr(getattr(client.api, "legacy", None), "observations_v1", None)
+    if legacy is not None and legacy.last_get_many_kwargs is not None:
+        return legacy
+    return client.api.observations
+
+
+def _observation_get_fake(client):
+    """Return whichever fake namespace recorded the last single-fetch call (v3 vs v4 legacy)."""
+    legacy = getattr(getattr(client.api, "legacy", None), "observations_v1", None)
+    if legacy is not None and legacy.last_get_kwargs is not None:
+        return legacy
+    return client.api.observations
 
 
 def test_fetch_traces_with_observations(state):
@@ -59,11 +90,11 @@ def test_fetch_trace(state):
     assert state.langfuse_client.api.trace.last_get_kwargs == {"trace_id": "trace_1"}
 
 
-def test_fetch_observations(state):
-    """fetch_observations should call the v3 observations resource."""
+def test_fetch_observations(observation_state):
+    """fetch_observations should drive the active page-based observations endpoint."""
     from langfuse_mcp.__main__ import fetch_observations
 
-    ctx = FakeContext(state)
+    ctx = FakeContext(observation_state)
     result = asyncio.run(
         fetch_observations(
             ctx,
@@ -80,19 +111,51 @@ def test_fetch_observations(state):
     )
     assert result["metadata"]["item_count"] == 1
     assert result["data"][0]["id"] == "obs_1"
-    assert state.langfuse_client.api.observations.last_get_many_kwargs is not None
-    obs_kwargs = state.langfuse_client.api.observations.last_get_many_kwargs
-    assert obs_kwargs["limit"] == 50
+
+    namespace = _observation_list_fake(observation_state.langfuse_client)
+    assert namespace.last_get_many_kwargs is not None
+    assert namespace.last_get_many_kwargs["limit"] == 50
 
 
-def test_fetch_observation(state):
-    """fetch_observation should hit the observations resource."""
+def test_fetch_observation(observation_state):
+    """fetch_observation should resolve via the v3 namespace or the v4 legacy_v1 fallback."""
     from langfuse_mcp.__main__ import fetch_observation
 
-    ctx = FakeContext(state)
+    ctx = FakeContext(observation_state)
     result = asyncio.run(fetch_observation(ctx, observation_id="obs_1", output_mode="compact"))
     assert result["data"]["id"] == "obs_1"
-    assert state.langfuse_client.api.observations.last_get_kwargs == {"observation_id": "obs_1"}
+
+    namespace = _observation_get_fake(observation_state.langfuse_client)
+    last = namespace.last_get_kwargs
+    assert last is not None
+    assert last["observation_id"] == "obs_1"
+
+
+def test_list_observations_cursor_only_rejects_page_gt_one(tmp_path):
+    """A v4 client without the page-based legacy fallback must raise on page>1."""
+    from types import SimpleNamespace
+
+    from langfuse_mcp.__main__ import _list_observations
+
+    def cursor_only_get_many(*, cursor=None, limit=None, **_: object):
+        return SimpleNamespace(data=[], meta=SimpleNamespace(cursor=None))
+
+    cursor_client = SimpleNamespace(api=SimpleNamespace(observations=SimpleNamespace(get_many=cursor_only_get_many)))
+
+    with pytest.raises(RuntimeError, match="legacy.observations_v1"):
+        _list_observations(
+            cursor_client,
+            limit=10,
+            page=2,
+            from_start_time=None,
+            to_start_time=None,
+            obs_type=None,
+            name=None,
+            user_id=None,
+            trace_id=None,
+            parent_observation_id=None,
+            metadata=None,
+        )
 
 
 def test_fetch_sessions(state):

--- a/tests/test_v4_smoke.py
+++ b/tests/test_v4_smoke.py
@@ -16,9 +16,12 @@ the suite already covers. With v3 installed (or v4 missing entirely) the
 Run against a v4 venv::
 
     uv venv --python 3.11 .venv-v4
-    .venv-v4/bin/uv pip install -e ".[dev]" "langfuse>=4.0.0,<5.0.0"
+    uv pip install --python .venv-v4/bin/python -e ".[dev]" "langfuse>=4.0.0,<5.0.0"
     LANGFUSE_PUBLIC_KEY=... LANGFUSE_SECRET_KEY=... \
         .venv-v4/bin/python -m pytest tests/test_v4_smoke.py -m integration -v -s
+
+(``uv venv`` doesn't install ``uv`` itself into the new venv, so we point
+the host ``uv`` at the venv's interpreter via ``--python``.)
 
 The ``-s`` flag is recommended so the introspection test prints which
 dispatcher path was selected — useful when verifying a new SDK release.
@@ -39,10 +42,11 @@ from typing import Any
 import pytest
 
 # Bypass the autouse ``patch_dependencies`` fixture in conftest.py — it stubs
-# out ``langfuse``, ``mcp.server.fastmcp``, and ``pydantic`` with hand-rolled
-# fakes that prevent the real SDK from being imported. The fixture runs at
-# module import time, so we have to clear the stubbed modules and import the
-# real ones before anything else can touch ``langfuse``.
+# out ``langfuse``, ``mcp.server.fastmcp``, ``pydantic``, and ``cachetools`` with
+# hand-rolled fakes that prevent the real SDK from being imported. The
+# ``_restore_real_langfuse`` fixture below clears those stubs from
+# ``sys.modules`` before each test body so real Langfuse imports against the
+# real installed wheels.
 _REAL_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY")
 _REAL_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY")
 _REAL_HOST = os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com")

--- a/tests/test_v4_smoke.py
+++ b/tests/test_v4_smoke.py
@@ -1,0 +1,337 @@
+"""Live smoke tests against a real Langfuse deployment.
+
+These tests verify the v3/v4 compatibility shim against a real ``Langfuse``
+client and the live HTTP API, rather than the in-memory fakes used by the
+rest of the suite.
+
+Skipped unless the standard Langfuse credentials are present in the
+environment (``LANGFUSE_PUBLIC_KEY``, ``LANGFUSE_SECRET_KEY``, optional
+``LANGFUSE_HOST`` defaulting to ``https://cloud.langfuse.com``).
+
+The smoke also requires ``langfuse>=4.0.0,<5.0.0`` to be installed —
+exercising it against the v3 SDK only re-tests the v3 path the rest of
+the suite already covers. With v3 installed (or v4 missing entirely) the
+``_require_v4_sdk`` skip fires.
+
+Run against a v4 venv::
+
+    uv venv --python 3.11 .venv-v4
+    .venv-v4/bin/uv pip install -e ".[dev]" "langfuse>=4.0.0,<5.0.0"
+    LANGFUSE_PUBLIC_KEY=... LANGFUSE_SECRET_KEY=... \
+        .venv-v4/bin/python -m pytest tests/test_v4_smoke.py -m integration -v -s
+
+The ``-s`` flag is recommended so the introspection test prints which
+dispatcher path was selected — useful when verifying a new SDK release.
+
+Write tests are gated behind ``LANGFUSE_MCP_SMOKE_DATASET`` (an existing
+dataset name in the project) because creating an annotation queue leaves
+data behind that has no exposed delete tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+# Bypass the autouse ``patch_dependencies`` fixture in conftest.py — it stubs
+# out ``langfuse``, ``mcp.server.fastmcp``, and ``pydantic`` with hand-rolled
+# fakes that prevent the real SDK from being imported. The fixture runs at
+# module import time, so we have to clear the stubbed modules and import the
+# real ones before anything else can touch ``langfuse``.
+_REAL_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY")
+_REAL_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY")
+_REAL_HOST = os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (_REAL_PUBLIC_KEY and _REAL_SECRET_KEY),
+        reason="LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY must be set for live smoke tests",
+    ),
+]
+
+
+_STUBBED_MODULE_PREFIXES = (
+    "langfuse",
+    "langfuse_mcp",
+    "pydantic",
+    "mcp",
+    "cachetools",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_langfuse(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo conftest's autouse module stubs for this file only.
+
+    ``tests/conftest.py`` installs fake ``langfuse``, ``pydantic``, ``mcp``
+    (and submodules), and ``cachetools`` into ``sys.modules`` so the rest of
+    the suite can import ``langfuse_mcp`` without the real dependencies. The
+    fake ``pydantic`` in particular is missing ``VERSION`` and other attrs
+    that real Langfuse imports rely on. This fixture runs before each test
+    body (after ``conftest.patch_dependencies`` has already inserted the
+    stubs) and drops every stubbed package so the real installed wheels load.
+    """
+    import sys
+
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in _STUBBED_MODULE_PREFIXES):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    yield
+
+
+def _require_v4_sdk() -> str:
+    """Return the installed ``langfuse`` version after asserting it's a v4."""
+    sdk_version = importlib.metadata.version("langfuse")
+    major = int(sdk_version.split(".", 1)[0])
+    if major < 4:
+        pytest.skip(
+            f"This smoke targets v4 SDK behavior (legacy.observations_v1 fallback, scores.get_many, "
+            f"annotation_queue direct-kwargs). Installed `langfuse=={sdk_version}` is v{major}; "
+            f"install langfuse>=4.0.0,<5.0.0 to run."
+        )
+    return sdk_version
+
+
+def _make_state(tmp_path):
+    """Construct an MCPState backed by a real ``Langfuse`` client."""
+    from langfuse import Langfuse
+
+    from langfuse_mcp.__main__ import MCPState
+
+    client = Langfuse(
+        public_key=_REAL_PUBLIC_KEY,
+        secret_key=_REAL_SECRET_KEY,
+        host=_REAL_HOST,
+        tracing_enabled=False,
+        flush_at=0,
+        flush_interval=None,
+    )
+    return MCPState(langfuse_client=client, dump_dir=str(tmp_path))
+
+
+def _ctx(state):
+    """Wrap state in the shape ``Context.request_context.lifespan_context`` expects."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=state))
+
+
+# ---------- Dispatcher introspection ----------
+
+
+def test_dispatcher_paths_against_live_sdk(tmp_path, capsys):
+    """Print which compat dispatcher path is selected against the live SDK.
+
+    This isn't strictly a behavior test — it's a diagnostic that prints the
+    SDK version, the observation list/single-fetch route selection, and the
+    score namespace name. Useful when bumping ``langfuse`` to a new release
+    to confirm the shim is still picking the route you expect.
+    """
+    from langfuse_mcp import _compat
+
+    sdk_version = _require_v4_sdk()
+    state = _make_state(tmp_path)
+
+    score_ns = _compat.get_score_namespace(state.langfuse_client)
+    score_ns_name = type(score_ns).__name__ if score_ns is not None else None
+
+    list_method = _compat.get_observations_list_method(state.langfuse_client)
+    if list_method is not None:
+        method, mode = list_method
+        list_repr = f"{type(method.__self__).__name__}.{method.__name__} ({mode})"
+    else:
+        list_repr = "<unsupported>"
+
+    fetcher = _compat.get_observations_single_fetcher(state.langfuse_client)
+    fetcher_repr = "<present>" if fetcher is not None else "<unsupported>"
+
+    print()
+    print(f"langfuse-version    : {sdk_version}")
+    print(f"score-namespace     : {score_ns_name}")
+    print(f"observations-list   : {list_repr}")
+    print(f"observations-single : {fetcher_repr}")
+
+    assert sdk_version
+    assert score_ns is not None, "Both api.scores and api.score_v_2 missing"
+    assert list_method is not None, "No observation list endpoint found"
+    assert fetcher is not None, "No observation single-fetch endpoint found"
+
+
+# ---------- Read smoke (always safe — no writes) ----------
+
+
+def test_fetch_traces_live(tmp_path):
+    """``fetch_traces`` should round-trip against the live API on both v3 and v4."""
+    from langfuse_mcp.__main__ import fetch_traces
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    result = asyncio.run(
+        fetch_traces(
+            _ctx(state),
+            age=1,
+            name=None,
+            user_id=None,
+            session_id=None,
+            metadata=None,
+            page=1,
+            limit=5,
+            tags=None,
+            include_observations=False,
+            output_mode="compact",
+        )
+    )
+    assert "data" in result and "metadata" in result
+    assert isinstance(result["data"], list)
+    assert result["metadata"]["item_count"] == len(result["data"])
+
+
+def test_fetch_observations_live(tmp_path):
+    """``fetch_observations`` should round-trip; v4 routes through legacy.observations_v1."""
+    from langfuse_mcp.__main__ import fetch_observations
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    result = asyncio.run(
+        fetch_observations(
+            _ctx(state),
+            type=None,
+            age=1,
+            name=None,
+            user_id=None,
+            trace_id=None,
+            parent_observation_id=None,
+            page=1,
+            limit=5,
+            output_mode="compact",
+        )
+    )
+    assert "data" in result and "metadata" in result
+    assert isinstance(result["data"], list)
+
+
+def test_fetch_observation_live_when_present(tmp_path):
+    """``fetch_observation`` should resolve through the live single-fetch route when an observation exists."""
+    from langfuse_mcp.__main__ import fetch_observation, fetch_observations
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    listed = asyncio.run(
+        fetch_observations(
+            _ctx(state),
+            type=None,
+            age=7,
+            name=None,
+            user_id=None,
+            trace_id=None,
+            parent_observation_id=None,
+            page=1,
+            limit=1,
+            output_mode="compact",
+        )
+    )
+    if not listed["data"]:
+        pytest.skip("No observations in the project's last 7 days; skipping single-fetch probe")
+
+    obs_id: Any = listed["data"][0].get("id")
+    assert obs_id, f"observation listing did not include an 'id' field: {listed['data'][0]!r}"
+
+    fetched = asyncio.run(fetch_observation(_ctx(state), observation_id=obs_id, output_mode="compact"))
+    assert fetched["data"]
+    assert fetched["data"].get("id") == obs_id
+
+
+def test_list_scores_v2_live(tmp_path):
+    """``list_scores_v2`` should reach the right namespace on both SDK majors."""
+    from langfuse_mcp.__main__ import list_scores_v2
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    result = asyncio.run(list_scores_v2(_ctx(state), page=1, limit=5))
+    assert "data" in result and "metadata" in result
+    assert isinstance(result["data"], list)
+
+
+def test_list_annotation_queues_live(tmp_path):
+    """``list_annotation_queues`` should round-trip on both SDK majors."""
+    from langfuse_mcp.__main__ import list_annotation_queues
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    result = asyncio.run(list_annotation_queues(_ctx(state), page=1, limit=5))
+    assert "data" in result and "metadata" in result
+
+
+def test_list_datasets_live(tmp_path):
+    """``list_datasets`` should round-trip on both SDK majors."""
+    from langfuse_mcp.__main__ import list_datasets
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    result = asyncio.run(list_datasets(_ctx(state), page=1, limit=5))
+    assert "data" in result and "metadata" in result
+
+
+def test_list_prompts_live(tmp_path):
+    """``list_prompts`` should round-trip; verifies the prompts API surface."""
+    from langfuse_mcp.__main__ import list_prompts
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    result = asyncio.run(list_prompts(_ctx(state), page=1, limit=5))
+    assert "data" in result and "metadata" in result
+
+
+# ---------- Write smoke (opt-in via env var so we don't pollute) ----------
+
+
+_SMOKE_DATASET = os.environ.get("LANGFUSE_MCP_SMOKE_DATASET")
+
+
+@pytest.mark.skipif(
+    not _SMOKE_DATASET,
+    reason="LANGFUSE_MCP_SMOKE_DATASET must point to an existing dataset name to exercise dataset-item writes",
+)
+def test_create_then_delete_dataset_item_live(tmp_path):
+    """Round-trip a dataset_item create + delete to verify the v4 direct-kwargs path.
+
+    The v4 ``Langfuse.create_dataset_item`` and ``api.dataset_items.delete``
+    surfaces are the most likely place the v3 ``request=<PydanticModel>``
+    style would surface a Pydantic validation error if our coercion is wrong.
+    Cleanup deletes the item in a ``finally`` so even an assertion failure
+    after a successful create can't leave the dataset polluted.
+    """
+    from langfuse_mcp.__main__ import create_dataset_item, delete_dataset_item
+
+    _require_v4_sdk()
+    state = _make_state(tmp_path)
+    item_id = f"smoke-{uuid.uuid4().hex[:12]}"
+    created_id: str | None = None
+    try:
+        created = asyncio.run(
+            create_dataset_item(
+                _ctx(state),
+                dataset_name=_SMOKE_DATASET,
+                input={"prompt": "smoke test"},
+                expected_output="smoke result",
+                metadata={"smoke": True},
+                source_trace_id=None,
+                source_observation_id=None,
+                item_id=item_id,
+                status="ACTIVE",
+            )
+        )
+        # Capture id for cleanup BEFORE asserting on shape, so a shape mismatch
+        # in the response payload doesn't strand the item in the dataset.
+        created_id = (created.get("data") or {}).get("id") or item_id
+        assert created["metadata"]["created"] is True
+    finally:
+        if created_id is not None:
+            deleted = asyncio.run(delete_dataset_item(_ctx(state), item_id=created_id))
+            assert deleted["metadata"]["deleted"] is True


### PR DESCRIPTION
## Summary
- Lift the SDK pin to `langfuse>=3.11.2,<5.0.0`, closing #40, while keeping v3.11.2+ supported.
- Add `langfuse_mcp/_compat.py` so MCP tool calls auto-select the right SDK surface across v3 and v4 via capability checks (`hasattr` + `inspect.signature`), never via a sniffed version flag. The MCP tool schema is unchanged.

## What v4 changed (and how this PR adapts)
- `langfuse.api.resources.<x>.types.<y>` flattened to `langfuse.api.<x>.types.<y>` — `_compat.resolve_request_model` lazy-imports v4 first, falls back to v3.
- `client.api.score_v_2` → `client.api.scores`; method `get` → `get_many` — `get_score_namespace` + `get_score_list_method` resolve transparently.
- `client.api.observations.get(observation_id=)` removed in v4 — `get_observations_single_fetcher` precedence is v3 → `legacy.observations_v1.get` → top-level `fetch_observation` shim with envelope unwrap.
- `client.api.observations.get_many` switched to cursor pagination on v4 — `get_observations_list_method` requires the `page` param to be present on candidate methods, falling through to cursor mode only when no page-capable route exists. `page > 1` against a cursor-only client raises `ERR_LANGFUSE_OBSERVATIONS_CURSOR_PAGE_UNSUPPORTED` rather than silently returning page 1.
- Annotation queue write methods (`create_queue`, `create_queue_item`, `update_queue_item`, `create_queue_assignment`, `delete_queue_assignment`) dropped `request=<PydanticModel>` for direct kwargs — `call_with_request_or_kwargs` dispatches v3 vs v4 and threads `path_kwargs={queue_id, item_id}` through both branches as keywords (no `functools.partial`).
- `method_has_param` is tri-state (`Optional[bool]`); the write-path dispatcher raises on `None` instead of silently choosing v4.
- `_extract_items_from_response` now preserves `.meta` pagination on the `.data` branch (was previously dropped).
- The `api.datasets.create` / `api.dataset_items.create` v3-vs-v4 fallback was deleted: real v3.11.2+ and v4.0.0+ both expose top-level `Langfuse.create_dataset` / `create_dataset_item` shortcuts. Missing the shortcut now raises an explicit `RuntimeError`.

## Tests
- New `tests/test_compat.py` (28 unit tests) covering tri-state introspection, dispatcher unknown-shape error, `path_kwargs` threading on both branches, legacy_v1 capability gating, and `ImportError` propagation.
- New `FakeAPIV4` / `FakeLangfuseV4` mirror real v4 SDK signatures (no `**kwargs` on write methods so v3-shape drift loud-fails).
- Observations, scores, and annotation queue tests parametrized `[v3, v4]` so each tool exercises both fake shapes.
- 95 / 95 pytest green; ruff check + format clean.

## Verification
- `langfuse==3.14.5`, `4.0.0`, and `4.5.1`: live `Langfuse` import + `_compat` dispatcher selection probed for the observation list/fetch paths and `Langfuse.create_dataset` / `create_dataset_item` shortcut presence.
- v4 annotation queue, dataset, dataset_item, and score signatures cross-checked against `langfuse-python` v4.0.6 source.
- Reviewed by Codex (twice — first pass on the original slices, second pass after the ChatGPT Pro round-trip surfaced 5 Required findings) and by ChatGPT Pro via yoetz browser recipe.

## Notes for downstream consumers
v4 adds `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` as transitive dependencies. langfuse-mcp instantiates the client with `tracing_enabled=False`, so no traces are emitted by default.

## Test plan
- [x] `uv run -m pytest` — 95 passed
- [x] `uv run -m ruff check langfuse_mcp tests` — clean
- [x] `uv run -m ruff format --check langfuse_mcp tests` — clean
- [x] Real-SDK import + dispatch probe vs v3.14.5 / v4.0.0 / v4.5.1 (Codex)
- [ ] CI passes on this PR

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)