### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.10', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Re-enabled Python 3.14 support now that the supported Langfuse SDK range includes v4, which uses Pydantic v2; CI now covers Python 3.10 through 3.14.
+
 ## [0.9.0] - 2026-04-29
 ### Changed
 - Allow `langfuse>=4.0.0,<5.0.0` alongside the existing `>=3.11.2,<4.0.0` range so projects can pin langfuse-mcp without blocking the v4.x SDK upgrade (closes #40).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://badge.fury.io/py/langfuse-mcp.svg)](https://badge.fury.io/py/langfuse-mcp)
 [![Downloads](https://static.pepy.tech/badge/langfuse-mcp)](https://pepy.tech/projects/langfuse-mcp)
-[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10–3.13-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10–3.14](https://img.shields.io/badge/python-3.10–3.14-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [Model Context Protocol](https://modelcontextprotocol.io) server for [Langfuse](https://langfuse.com) observability. Query traces, debug errors, analyze sessions, manage prompts.

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -24,12 +24,6 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
-if sys.version_info >= (3, 14):
-    raise SystemExit(
-        "langfuse-mcp currently requires Python 3.13 or earlier. "
-        "Please rerun with `uvx --python 3.11 langfuse-mcp` or pin a supported interpreter."
-    )
-
 from cachetools import LRUCache
 from langfuse import Langfuse
 from mcp.server.fastmcp import Context, FastMCP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ description = "Langfuse MCP server for accessing and analyzing telemetry data vi
 authors = [
     {name = "Aviv Sinai", email = "avivsinai@gmail.com"}
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 classifiers = [
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords = ["mcp", "langfuse", "observability", "tracing", "agents", "llm", "debugging"]
 dependencies = [

--- a/skills/langfuse/references/setup.md
+++ b/skills/langfuse/references/setup.md
@@ -44,9 +44,9 @@ Never commit credentials to version control.
 
 ### Python Version Errors
 
-If MCP fails to connect, check your Python version. The Langfuse SDK requires Python 3.13 or earlier (due to Pydantic v1 dependency).
+If MCP fails to connect, check your Python version. Langfuse MCP requires Python 3.10 or newer and CI currently verifies Python 3.10 through 3.14.
 
-Fix by pinning Python in the uvx command:
+If your default interpreter is older than Python 3.10, pin a supported Python in the uvx command:
 ```bash
 uvx --python 3.11 langfuse-mcp
 ```


### PR DESCRIPTION
## Summary

Re-enables Python 3.14 now that the supported Langfuse SDK range includes v4, which uses Pydantic v2 and installs cleanly on Python 3.14.

## Changes

- Remove the Python 3.14 runtime guard
- Relax package metadata to Python >=3.10 and add the Python 3.14 classifier
- Add Python 3.11 and 3.14 to the CI test matrix
- Update README badge, skill troubleshooting docs, and changelog

## Testing

- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Type check passes (`pyright`)
- [x] Tests pass (`python -m pytest -v --tb=short`) on Python 3.14.4: 95 passed, 9 skipped
- [x] CLI smoke passes (`langfuse-mcp --help`) on Python 3.14.4
- [x] Documentation updated
- [x] CHANGELOG.md updated
- [x] Claude Code reviewed Python 3.14 viability via AMQ

## Related Issues

Closes #44