### PR TITLE
docs: align Python 3.14 setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project provides a **full observability toolkit** — traces, observations,
 
 ## Quick Start
 
-Requires [uv](https://docs.astral.sh/uv/getting-started/installation/) (for `uvx`).
+Requires [uv](https://docs.astral.sh/uv/getting-started/installation/) (for `uvx`) and Python 3.10 or newer. CI verifies Python 3.10 through 3.14.
 
 Get credentials from [Langfuse Cloud](https://cloud.langfuse.com) → Settings → API Keys. If self-hosted, use your instance URL for `LANGFUSE_HOST`.
 
@@ -37,15 +37,17 @@ claude mcp add \
   -e LANGFUSE_SECRET_KEY=sk-... \
   -e LANGFUSE_HOST=https://cloud.langfuse.com \
   --scope project \
-  langfuse -- uvx --python 3.11 langfuse-mcp
+  langfuse -- uvx langfuse-mcp
 
 # Codex CLI (user-scoped, stored in ~/.codex/config.toml)
 codex mcp add langfuse \
   --env LANGFUSE_PUBLIC_KEY=pk-... \
   --env LANGFUSE_SECRET_KEY=sk-... \
   --env LANGFUSE_HOST=https://cloud.langfuse.com \
-  -- uvx --python 3.11 langfuse-mcp
+  -- uvx langfuse-mcp
 ```
+
+To pin a CI-verified interpreter explicitly, add `--python 3.14` before `langfuse-mcp`.
 
 Restart your CLI, then verify with `/mcp` (Claude Code) or `codex mcp list` (Codex).
 
@@ -147,7 +149,7 @@ Create `.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` for global):
   "mcpServers": {
     "langfuse": {
       "command": "uvx",
-      "args": ["--python", "3.11", "langfuse-mcp"],
+      "args": ["langfuse-mcp"],
       "env": {
         "LANGFUSE_PUBLIC_KEY": "pk-...",
         "LANGFUSE_SECRET_KEY": "sk-...",
@@ -178,7 +180,7 @@ docker run --rm -i \
 ## Development
 
 ```bash
-uv venv --python 3.11 .venv && source .venv/bin/activate
+uv venv --python 3.14 .venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
 pytest
 ```

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -21,6 +21,8 @@ If self-hosted, use your instance URL for `LANGFUSE_HOST` and create keys there.
 
 **Step 2:** Install MCP (pick one):
 
+Requires Python 3.10 or newer. CI verifies Python 3.10 through 3.14.
+
 ```bash
 # Claude Code (project-scoped, shared via .mcp.json)
 claude mcp add \
@@ -28,15 +30,17 @@ claude mcp add \
   --env LANGFUSE_PUBLIC_KEY=pk-... \
   --env LANGFUSE_SECRET_KEY=sk-... \
   --env LANGFUSE_HOST=https://cloud.langfuse.com \
-  langfuse -- uvx --python 3.11 langfuse-mcp
+  langfuse -- uvx langfuse-mcp
 
 # Codex CLI (user-scoped, stored in ~/.codex/config.toml)
 codex mcp add langfuse \
   --env LANGFUSE_PUBLIC_KEY=pk-... \
   --env LANGFUSE_SECRET_KEY=sk-... \
   --env LANGFUSE_HOST=https://cloud.langfuse.com \
-  -- uvx --python 3.11 langfuse-mcp
+  -- uvx langfuse-mcp
 ```
+
+Add `--python 3.14` before `langfuse-mcp` if you want to pin a CI-verified interpreter explicitly.
 
 **Step 3:** Restart CLI, verify with `/mcp` (Claude) or `codex mcp list` (Codex)
 

--- a/skills/langfuse/references/setup.md
+++ b/skills/langfuse/references/setup.md
@@ -11,7 +11,7 @@ If you prefer manual configuration over `claude mcp add`:
   "mcpServers": {
     "langfuse": {
       "command": "uvx",
-      "args": ["--python", "3.11", "langfuse-mcp"],
+      "args": ["langfuse-mcp"],
       "env": {
         "LANGFUSE_PUBLIC_KEY": "pk-...",
         "LANGFUSE_SECRET_KEY": "sk-...",
@@ -46,14 +46,14 @@ Never commit credentials to version control.
 
 If MCP fails to connect, check your Python version. Langfuse MCP requires Python 3.10 or newer and CI currently verifies Python 3.10 through 3.14.
 
-If your default interpreter is older than Python 3.10, pin a supported Python in the uvx command:
+If your default interpreter is older than Python 3.10, pin a CI-verified Python in the uvx command:
 ```bash
-uvx --python 3.11 langfuse-mcp
+uvx --python 3.14 langfuse-mcp
 ```
 
 Or verify manually:
 ```bash
-uvx --python 3.11 langfuse-mcp --help
+uvx --python 3.14 langfuse-mcp --help
 ```
 
 ### Timeout Errors
@@ -67,10 +67,10 @@ claude mcp add \
   --env LANGFUSE_PUBLIC_KEY=pk-... \
   --env LANGFUSE_SECRET_KEY=sk-... \
   --env LANGFUSE_HOST=https://cloud.langfuse.com \
-  langfuse -- uvx --python 3.11 langfuse-mcp --timeout 60
+  langfuse -- uvx langfuse-mcp --timeout 60
 
 # Or in .mcp.json
-"args": ["--python", "3.11", "langfuse-mcp", "--timeout", "60"]
+"args": ["langfuse-mcp", "--timeout", "60"]
 ```
 
 ### Empty Results


### PR DESCRIPTION
## Summary

Updates README and bundled Langfuse skill setup docs now that Python 3.14 support is merged to `main`.

Research trail:
- #44 reported that the old Python 3.14 limitation looked stale.
- #45 re-enabled Python 3.14 support, relaxed package metadata to `>=3.10`, added the Python 3.14 classifier, and added CI coverage for Python 3.10 through 3.14.

## Changes

- Document Python 3.10+ with CI coverage through Python 3.14 in README Quick Start.
- Remove stale `uvx --python 3.11` pins from README client setup examples.
- Update Cursor and development examples to avoid implying 3.11 is required.
- Align bundled skill setup and troubleshooting docs with the same guidance.

## Testing

Local Python 3.14.4 venv at `/tmp/langfuse-mcp-py314-test`, with `langfuse==4.5.1` and `pydantic==2.13.3`:

- [x] `/tmp/langfuse-mcp-py314-test/bin/python -m pytest -v --tb=short` — 95 passed, 9 skipped
- [x] `/tmp/langfuse-mcp-py314-test/bin/ruff check .`
- [x] `/tmp/langfuse-mcp-py314-test/bin/ruff format --check .`
- [x] `/tmp/langfuse-mcp-py314-test/bin/pyright`
- [x] `/tmp/langfuse-mcp-py314-test/bin/langfuse-mcp --help`
- [x] `make check-skills`
- [x] `git diff --check`
- [x] docs assertions confirming stale Python 3.11/3.14-blocking guidance is gone from README and bundled skill docs

Note: local `uv` is 0.8.22 and warns on `[tool.uv] exclude-newer = "7 days"`; per `CLAUDE.md`, that syntax requires uv >= 0.9 and is a local toolchain issue, not a repo config failure.
