### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-06
 ### Changed
 - Re-enabled Python 3.14 support now that the supported Langfuse SDK range includes v4, which uses Pydantic v2; CI now covers Python 3.10 through 3.14.
+
 
 ## [0.9.0] - 2026-04-29
 ### Changed

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse
-version: 0.9.0
+version: 0.9.1
 description: Debug AI traces, find exceptions, analyze sessions, and manage prompts via Langfuse MCP. Use when debugging AI pipelines, investigating errors, analyzing latency, managing prompt versions, or setting up Langfuse. Triggers on "langfuse", "traces", "debug AI", "find exceptions", "what went wrong", "why is it slow", "datasets", "evaluation sets".
 metadata:
   short-description: Langfuse observability via MCP


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.9.1`
- aligns skill/plugin metadata to `0.9.1`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.9.1`, publishes the GitHub release, then publishes to PyPI, Docker (GHCR), and the skills marketplace in the same workflow run