### PR TITLE
feature/add opportunity to multiproject work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Streamable HTTP transport** (`--transport streamable-http`): run a single persistent
+  server instance that serves multiple MCP clients over HTTP, eliminating the need for
+  one process/container per project.
+  - `--bind-host` (default `127.0.0.1`) and `--port` (default `8000`) control the
+    listening address. Expose on `0.0.0.0` only behind a TLS-terminating,
+    authenticating reverse-proxy or within a trusted network.
+  - `LANGFUSE_MCP_BIND_HOST` and `LANGFUSE_MCP_PORT` env-var counterparts.
+- **Per-request project credentials via `Authorization: Basic`**: pass
+  `Authorization: Basic <base64(public_key:secret_key)>` on each HTTP request to
+  target a specific Langfuse project. Absent header falls back to startup env
+  credentials; any malformed value is rejected (fail closed — no silent fallback).
+  Per-project clients are cached in a bounded LRU (max 32 entries); evicted clients
+  are flushed and shut down to prevent resource leaks.
+
 ## [0.9.1] - 2026-05-06
 ### Changed
 - Re-enabled Python 3.14 support now that the supported Langfuse SDK range includes v4, which uses Pydantic v2; CI now covers Python 3.10 through 3.14.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Create `.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` for global):
 }
 ```
 
-### Docker
+### Docker (single project)
 
 ```bash
 docker run --rm -i \
@@ -170,6 +170,47 @@ docker run --rm -i \
   -e LANGFUSE_HOST=https://cloud.langfuse.com \
   ghcr.io/avivsinai/langfuse-mcp:latest
 ```
+
+### HTTP transport — shared server for multiple projects
+
+Run one persistent server instance and route each MCP client to its own Langfuse
+project by passing credentials in the `Authorization` header.
+
+```bash
+# Start a shared server (binds to localhost by default)
+docker run -d -p 127.0.0.1:8000:8000 \
+  -e LANGFUSE_HOST=https://cloud.langfuse.com \
+  ghcr.io/avivsinai/langfuse-mcp:latest \
+  --transport streamable-http --bind-host 0.0.0.0
+```
+
+> **Security note:** `--bind-host 0.0.0.0` exposes the port on all interfaces. In
+> production, place the server behind a TLS-terminating reverse proxy (nginx, Caddy,
+> Cloudflare Tunnel) that enforces HTTPS. The `Authorization` header containing your
+> keys is transmitted in plaintext over plain HTTP.
+
+Register each project separately in your MCP client, passing its credentials as a
+`Basic` auth header (`base64(public_key:secret_key)`):
+
+```bash
+# Generate the header value for each project:
+echo -n "pk-lf-YOURKEY:sk-lf-YOURSECRET" | base64
+# cGstbGYtWU9VUktFWTpzay1sZi1ZT1VSU0VDUkVU
+
+# Register in Claude Code (one entry per project):
+claude mcp add langfuse-audit \
+  --transport http http://localhost:8000 \
+  -H "Authorization: Basic cGstbGYtWU9VUktFWTpzay1sZi1ZT1VSU0VDUkVU"
+
+claude mcp add langfuse-staging \
+  --transport http http://localhost:8000 \
+  -H "Authorization: Basic <base64 for staging project>"
+```
+
+**Auth semantics:** `Basic` here carries Langfuse API keys, not user passwords. An
+absent header falls back to startup env credentials (`LANGFUSE_PUBLIC_KEY` /
+`LANGFUSE_SECRET_KEY`). Any malformed header is rejected outright — there is no
+silent fallback to a different project.
 
 ### Optional environment variables
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,11 @@ docker run -d -p 127.0.0.1:8000:8000 \
 > **Security note:** `--bind-host 0.0.0.0` exposes the port on all interfaces. In
 > production, place the server behind a TLS-terminating reverse proxy (nginx, Caddy,
 > Cloudflare Tunnel) that enforces HTTPS. The `Authorization` header containing your
-> keys is transmitted in plaintext over plain HTTP.
+> keys is transmitted in plaintext over plain HTTP. If startup credentials are set,
+> the proxy must enforce authentication; otherwise unauthenticated callers without an
+> `Authorization` header can use the default project. For shared public HTTP deployments,
+> omit default `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` credentials unless the
+> fronting proxy authenticates every request.
 
 Register each project separately in your MCP client, passing its credentials as a
 `Basic` auth header (`base64(public_key:secret_key)`):
@@ -199,11 +203,11 @@ echo -n "pk-lf-YOURKEY:sk-lf-YOURSECRET" | base64
 
 # Register in Claude Code (one entry per project):
 claude mcp add langfuse-audit \
-  --transport http http://localhost:8000 \
+  --transport http http://localhost:8000/mcp \
   -H "Authorization: Basic cGstbGYtWU9VUktFWTpzay1sZi1ZT1VSU0VDUkVU"
 
 claude mcp add langfuse-staging \
-  --transport http http://localhost:8000 \
+  --transport http http://localhost:8000/mcp \
   -H "Authorization: Basic <base64 for staging project>"
 ```
 

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -5,6 +5,7 @@ agents to query trace data, observations, and exceptions from Langfuse.
 """
 
 import argparse
+import base64
 import functools
 import inspect
 import json
@@ -1115,18 +1116,51 @@ class MCPState:
     )
 
 
-def _resolve_client(state: "MCPState", ctx: Context) -> Langfuse:
-    """Resolve a Langfuse client from HTTP request headers or fall back to the default.
+def _parse_basic_auth(header: str) -> tuple[str, str]:
+    """Parse an ``Authorization: Basic`` header into ``(public_key, secret_key)``.
 
-    Reads x-langfuse-public-key and x-langfuse-secret-key from the incoming HTTP
-    request headers. If present, creates (or reuses a cached) project-specific client.
-    Falls back to the startup-configured default client if no headers are provided.
+    Raises ``ValueError`` on any malformed input so callers fail closed.
+    The secret_key never appears in error messages or logs.
+
+    Args:
+        header: Raw value of the Authorization HTTP header.
+
+    Returns:
+        Tuple of (public_key, secret_key).
+    """
+    scheme, _, credentials = header.partition(" ")
+    if scheme.lower() != "basic":
+        raise ValueError(f"Unsupported Authorization scheme '{scheme}'; expected 'Basic'.")
+    if not credentials.strip():
+        raise ValueError("Authorization header is missing credentials.")
+    try:
+        decoded = base64.b64decode(credentials.strip().encode()).decode("utf-8")
+    except Exception:
+        raise ValueError("Authorization credentials are not valid base64.")
+    if ":" not in decoded:
+        raise ValueError("Authorization credentials must be base64(public_key:secret_key).")
+    public_key, secret_key = decoded.split(":", 1)
+    if not public_key:
+        raise ValueError("public_key in Authorization credentials is empty.")
+    if not secret_key:
+        raise ValueError("secret_key in Authorization credentials is empty.")
+    return public_key, secret_key
+
+
+def _resolve_client(state: "MCPState", ctx: Context) -> Langfuse:
+    """Resolve a Langfuse client from an HTTP Authorization header or fall back to the default.
+
+    Reads ``Authorization: Basic <base64(public_key:secret_key)>`` from the incoming
+    HTTP request. If the header is present, it is parsed strictly — any malformed value
+    raises ``ValueError`` (fail closed). Only a *missing* header falls back to the
+    startup-configured default client.
     """
     request = getattr(ctx.request_context, "request", None)
     if request is not None:
-        public_key = request.headers.get("x-langfuse-public-key")
-        secret_key = request.headers.get("x-langfuse-secret-key")
-        if public_key and secret_key:
+        auth_header = request.headers.get("authorization")
+        if auth_header is not None:
+            # Raises ValueError on any malformed input — no silent fallback to default.
+            public_key, secret_key = _parse_basic_auth(auth_header)
             cache_key = (public_key, secret_key)
             if cache_key not in state.project_clients:
                 init_params = inspect.signature(Langfuse.__init__).parameters
@@ -1135,6 +1169,8 @@ def _resolve_client(state: "MCPState", ctx: Context) -> Langfuse:
                     "secret_key": secret_key,
                     "host": state.host,
                     "debug": False,
+                    # Disable background batching: per-request clients must not hold
+                    # background threads or accumulate events between MCP tool calls.
                     "flush_at": 0,
                     "flush_interval": None,
                 }
@@ -1142,14 +1178,14 @@ def _resolve_client(state: "MCPState", ctx: Context) -> Langfuse:
                     langfuse_kwargs["timeout"] = state.timeout
                 if "tracing_enabled" in init_params:
                     langfuse_kwargs["tracing_enabled"] = False
-                logger.info(f"Creating Langfuse client for public_key={public_key[:8]}...")
+                logger.info("Creating Langfuse client for public_key=%s…", public_key[:8])
                 state.project_clients[cache_key] = Langfuse(**langfuse_kwargs)
             return state.project_clients[cache_key]
     if state.langfuse_client is None:
         raise ValueError(
-            "No Langfuse credentials. Provide x-langfuse-public-key and "
-            "x-langfuse-secret-key HTTP headers, or set LANGFUSE_PUBLIC_KEY / "
-            "LANGFUSE_SECRET_KEY at startup."
+            "No Langfuse credentials. Provide an "
+            "'Authorization: Basic <base64(public_key:secret_key)>' header, "
+            "or set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY at startup."
         )
     return state.langfuse_client
 

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -345,15 +345,15 @@ def _build_arg_parser(env_defaults: dict[str, Any]) -> argparse.ArgumentParser:
         "--public-key",
         type=str,
         default=env_defaults["public_key"],
-        required=env_defaults["public_key"] is None,
-        help="Langfuse public key",
+        required=False,
+        help="Langfuse public key (optional if provided via x-langfuse-public-key HTTP header)",
     )
     parser.add_argument(
         "--secret-key",
         type=str,
         default=env_defaults["secret_key"],
-        required=env_defaults["secret_key"] is None,
-        help="Langfuse secret key",
+        required=False,
+        help="Langfuse secret key (optional if provided via x-langfuse-secret-key HTTP header)",
     )
     parser.add_argument("--host", type=str, default=env_defaults["host"], help="Langfuse host URL")
     parser.add_argument(
@@ -412,6 +412,25 @@ def _build_arg_parser(env_defaults: dict[str, Any]) -> argparse.ArgumentParser:
         action="store_true",
         default=os.getenv("LANGFUSE_MCP_READ_ONLY", "").lower() in ("1", "true", "yes"),
         help="Disable all write operations (create/update/delete tools). Safer for read-only access.",
+    )
+    parser.add_argument(
+        "--transport",
+        type=str,
+        default=os.getenv("LANGFUSE_MCP_TRANSPORT", "stdio"),
+        choices=["stdio", "streamable-http"],
+        help="MCP transport: stdio (default) or streamable-http. Set via LANGFUSE_MCP_TRANSPORT.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("LANGFUSE_MCP_PORT", "8000")),
+        help="Port for HTTP transport (default: 8000). Set via LANGFUSE_MCP_PORT.",
+    )
+    parser.add_argument(
+        "--bind-host",
+        type=str,
+        default=os.getenv("LANGFUSE_MCP_BIND_HOST", "0.0.0.0"),
+        help="Bind address for HTTP transport (default: 0.0.0.0). Set via LANGFUSE_MCP_BIND_HOST.",
     )
 
     return parser
@@ -1038,7 +1057,11 @@ class MCPState:
     performance when querying and filtering observations and exceptions.
     """
 
-    langfuse_client: Langfuse
+    langfuse_client: Langfuse | None
+    host: str = "https://cloud.langfuse.com"
+    timeout: int = 30
+    # Per-request project clients keyed by (public_key, secret_key)
+    project_clients: dict[tuple[str, str], Langfuse] = field(default_factory=dict)
     # LRU caches for efficient exception lookup
     observation_cache: LRUCache = field(
         default_factory=lambda: LRUCache(maxsize=100), metadata={"description": "Cache for observations to reduce API calls"}
@@ -1059,6 +1082,45 @@ class MCPState:
         default=OutputMode.COMPACT,
         metadata={"description": "Default output_mode applied to MCP tool schemas and runtime fallbacks"},
     )
+
+
+def _resolve_client(state: "MCPState", ctx: Context) -> Langfuse:
+    """Resolve a Langfuse client from HTTP request headers or fall back to the default.
+
+    Reads x-langfuse-public-key and x-langfuse-secret-key from the incoming HTTP
+    request headers. If present, creates (or reuses a cached) project-specific client.
+    Falls back to the startup-configured default client if no headers are provided.
+    """
+    request = getattr(ctx.request_context, "request", None)
+    if request is not None:
+        public_key = request.headers.get("x-langfuse-public-key")
+        secret_key = request.headers.get("x-langfuse-secret-key")
+        if public_key and secret_key:
+            cache_key = (public_key, secret_key)
+            if cache_key not in state.project_clients:
+                init_params = inspect.signature(Langfuse.__init__).parameters
+                langfuse_kwargs: dict[str, Any] = {
+                    "public_key": public_key,
+                    "secret_key": secret_key,
+                    "host": state.host,
+                    "debug": False,
+                    "flush_at": 0,
+                    "flush_interval": None,
+                }
+                if "timeout" in init_params:
+                    langfuse_kwargs["timeout"] = state.timeout
+                if "tracing_enabled" in init_params:
+                    langfuse_kwargs["tracing_enabled"] = False
+                logger.info(f"Creating Langfuse client for public_key={public_key[:8]}...")
+                state.project_clients[cache_key] = Langfuse(**langfuse_kwargs)
+            return state.project_clients[cache_key]
+    if state.langfuse_client is None:
+        raise ValueError(
+            "No Langfuse credentials. Provide x-langfuse-public-key and "
+            "x-langfuse-secret-key HTTP headers, or set LANGFUSE_PUBLIC_KEY / "
+            "LANGFUSE_SECRET_KEY at startup."
+        )
+    return state.langfuse_client
 
 
 class ExceptionCount(BaseModel):
@@ -1134,7 +1196,7 @@ async def _efficient_fetch_observations(
     Returns:
         Dictionary of observation_id -> observation
     """
-    langfuse_client = state.langfuse_client
+    langfuse_client = state.langfuse_client  # type: ignore[assignment]  # dead code, never called
 
     # Use a cache key that includes the time range
     cache_key = f"{from_timestamp.isoformat()}-{to_timestamp.isoformat()}"
@@ -1207,13 +1269,13 @@ async def _efficient_fetch_observations(
     return observations
 
 
-async def _embed_observations_in_traces(state: MCPState, traces: list[Any]) -> None:
+async def _embed_observations_in_traces(langfuse_client: Langfuse, traces: list[Any]) -> None:
     """Fetch and embed full observation objects into traces.
 
     This replaces the observation IDs list with a list of the actual observation objects.
 
     Args:
-        state: MCP state with Langfuse client
+        langfuse_client: Langfuse client to use for fetching observations
         traces: List of trace objects to process
     """
     if not traces:
@@ -1242,7 +1304,7 @@ async def _embed_observations_in_traces(state: MCPState, traces: list[Any]) -> N
         full_observations = []
         for obs_id in observation_refs:
             try:
-                obs = _get_observation(state.langfuse_client, obs_id)
+                obs = _get_observation(langfuse_client, obs_id)
                 obs_data = _sdk_object_to_python(obs)
                 full_observations.append(obs_data)
                 logger.debug(f"Fetched observation {obs_id} for trace {trace.get('id', 'unknown')}")
@@ -1300,7 +1362,7 @@ async def fetch_traces(
 
         # Use the resource-style API when available (Langfuse v3) with fallback to v2 helpers
         trace_items, pagination = _list_traces(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=limit,
             page=page,
             include_observations=include_observations,
@@ -1318,7 +1380,7 @@ async def fetch_traces(
         # If include_observations is True, fetch and embed the full observation objects
         if include_observations and raw_traces:
             logger.info(f"Fetching full observation details for {sum(len(t.get('observations', [])) for t in raw_traces)} observations")
-            await _embed_observations_in_traces(state, raw_traces)
+            await _embed_observations_in_traces(_resolve_client(state, ctx), raw_traces)
 
         # Process based on output mode
         mode = _ensure_output_mode(output_mode)
@@ -1402,7 +1464,7 @@ async def fetch_trace(
 
     try:
         # Use the resource-style API when available
-        trace = _get_trace(state.langfuse_client, trace_id, include_observations)
+        trace = _get_trace(_resolve_client(state, ctx), trace_id, include_observations)
 
         # Convert response to a serializable format
         raw_trace = _sdk_object_to_python(trace)
@@ -1416,7 +1478,7 @@ async def fetch_trace(
             embedded = raw_trace.get("observations", []) if isinstance(raw_trace, dict) else []
             if embedded and isinstance(embedded[0], str):
                 logger.info(f"Fetching full observation details for {len(embedded)} observations")
-                await _embed_observations_in_traces(state, [raw_trace])
+                await _embed_observations_in_traces(_resolve_client(state, ctx), [raw_trace])
 
         # Process based on output mode
         mode = _ensure_output_mode(output_mode)
@@ -1494,7 +1556,7 @@ async def fetch_observations(
 
     try:
         observation_items, pagination = _list_observations(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=limit,
             page=page,
             from_start_time=from_start_time,
@@ -1569,7 +1631,7 @@ async def fetch_observation(
 
     try:
         # Use the resource-style API when available
-        observation = _get_observation(state.langfuse_client, observation_id)
+        observation = _get_observation(_resolve_client(state, ctx), observation_id)
 
         # Convert response to a serializable format
         raw_observation = _sdk_object_to_python(observation)
@@ -1633,7 +1695,7 @@ async def fetch_sessions(
 
     try:
         session_items, pagination = _list_sessions(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=limit,
             page=page,
             from_timestamp=from_timestamp,
@@ -1714,7 +1776,7 @@ async def get_session_details(
     try:
         # Fetch traces with this session ID
         trace_items, pagination = _list_traces(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=50,
             page=1,
             include_observations=include_observations,
@@ -1749,7 +1811,7 @@ async def get_session_details(
             total_observations = sum(len(t.get("observations", [])) for t in raw_traces)
             if total_observations > 0:
                 logger.info(f"Fetching full observation details for {total_observations} observations across {len(raw_traces)} traces")
-                await _embed_observations_in_traces(state, raw_traces)
+                await _embed_observations_in_traces(_resolve_client(state, ctx), raw_traces)
 
         # Create a session object with all traces that have this session ID
         session = {
@@ -1839,7 +1901,7 @@ async def get_user_sessions(
 
         # Fetch traces for this user
         trace_items, pagination = _list_traces(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=100,
             page=1,
             include_observations=include_observations,
@@ -1859,7 +1921,7 @@ async def get_user_sessions(
             total_observations = sum(len(t.get("observations", [])) for t in raw_traces)
             if total_observations > 0:
                 logger.info(f"Fetching full observation details for {total_observations} observations across {len(raw_traces)} traces")
-                await _embed_observations_in_traces(state, raw_traces)
+                await _embed_observations_in_traces(_resolve_client(state, ctx), raw_traces)
 
         # Group traces by session_id
         sessions_dict: dict[str, dict[str, Any]] = {}
@@ -1956,7 +2018,7 @@ async def find_exceptions(
     try:
         # Fetch all SPAN observations since they may contain exceptions
         observation_items, _ = _list_observations(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=100,
             page=1,
             from_start_time=from_timestamp,
@@ -2051,7 +2113,7 @@ async def find_exceptions_in_file(
     try:
         # Fetch all SPAN observations since they may contain exceptions
         observation_items, _ = _list_observations(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=100,
             page=1,
             from_start_time=from_timestamp,
@@ -2157,7 +2219,7 @@ async def get_exception_details(
 
     try:
         # First get the trace details
-        trace = _get_trace(state.langfuse_client, trace_id, include_observations=False)
+        trace = _get_trace(_resolve_client(state, ctx), trace_id, include_observations=False)
         trace_data = _sdk_object_to_python(trace)
         mode = _ensure_output_mode(output_mode)
         if not trace_data:
@@ -2172,7 +2234,7 @@ async def get_exception_details(
 
         # Get all observations for this trace
         observation_items, _ = _list_observations(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=100,
             page=1,
             from_start_time=None,
@@ -2288,7 +2350,7 @@ async def get_error_count(
     try:
         # Fetch all SPAN observations since they may contain exceptions
         observation_items, _ = _list_observations(
-            state.langfuse_client,
+            _resolve_client(state, ctx),
             limit=100,
             page=1,
             from_start_time=from_timestamp,
@@ -2506,7 +2568,7 @@ async def get_prompt(
         if version:
             kwargs["version"] = version
 
-        prompt = state.langfuse_client.get_prompt(**kwargs)
+        prompt = _resolve_client(state, ctx).get_prompt(**kwargs)
 
         if prompt is None:
             label_msg = f" with label '{label}'" if label else ""
@@ -2602,16 +2664,16 @@ async def get_prompt_unresolved(
             api_kwargs["version"] = version
 
         # Access the prompts API directly.
-        if not hasattr(state.langfuse_client, "api") or not hasattr(state.langfuse_client.api, "prompts"):
+        if not hasattr(_resolve_client(state, ctx), "api") or not hasattr(_resolve_client(state, ctx).api, "prompts"):
             raise RuntimeError("Langfuse SDK does not expose prompts.get; upgrade the SDK to use this tool.")
-        if not hasattr(state.langfuse_client.api.prompts, "get"):
+        if not hasattr(_resolve_client(state, ctx).api.prompts, "get"):
             raise RuntimeError("Langfuse SDK does not expose prompts.get; upgrade the SDK to use this tool.")
-        supports_resolve = _prompts_get_supports_resolve(state.langfuse_client.api.prompts)
+        supports_resolve = _prompts_get_supports_resolve(_resolve_client(state, ctx).api.prompts)
         try:
             if supports_resolve:
-                prompt_response = _prompts_get(state.langfuse_client.api.prompts, name=name, resolve=False, **api_kwargs)
+                prompt_response = _prompts_get(_resolve_client(state, ctx).api.prompts, name=name, resolve=False, **api_kwargs)
             else:
-                prompt_response = _prompts_get(state.langfuse_client.api.prompts, name=name, **api_kwargs)
+                prompt_response = _prompts_get(_resolve_client(state, ctx).api.prompts, name=name, **api_kwargs)
         except TypeError as e:
             msg = str(e)
             if "resolve" in msg or "unexpected keyword" in msg:
@@ -2680,7 +2742,7 @@ async def list_prompts(
             api_kwargs["tag"] = tag
 
         # Call prompts list API
-        response = state.langfuse_client.api.prompts.list(**api_kwargs)
+        response = _resolve_client(state, ctx).api.prompts.list(**api_kwargs)
 
         # Extract items and pagination
         items, pagination = _extract_items_from_response(response)
@@ -2766,7 +2828,7 @@ async def create_text_prompt(
         if commit_message is not None:
             create_kwargs["commit_message"] = commit_message
 
-        created_prompt = state.langfuse_client.create_prompt(**create_kwargs)
+        created_prompt = _resolve_client(state, ctx).create_prompt(**create_kwargs)
 
         result = {
             "name": getattr(created_prompt, "name", name),
@@ -2838,7 +2900,7 @@ async def create_chat_prompt(
         if commit_message is not None:
             create_kwargs["commit_message"] = commit_message
 
-        created_prompt = state.langfuse_client.create_prompt(**create_kwargs)
+        created_prompt = _resolve_client(state, ctx).create_prompt(**create_kwargs)
 
         prompt_content = None
         if hasattr(created_prompt, "prompt"):
@@ -2897,10 +2959,10 @@ async def update_prompt_labels(
 
         def _get_existing_labels() -> list[str]:
             try:
-                if hasattr(state.langfuse_client, "get_prompt"):
-                    prompt_obj = state.langfuse_client.get_prompt(name=name, version=version)
-                elif hasattr(state.langfuse_client, "api") and hasattr(state.langfuse_client.api, "prompts"):
-                    prompt_obj = _prompts_get(state.langfuse_client.api.prompts, name=name, version=version)
+                if hasattr(_resolve_client(state, ctx), "get_prompt"):
+                    prompt_obj = _resolve_client(state, ctx).get_prompt(name=name, version=version)
+                elif hasattr(_resolve_client(state, ctx), "api") and hasattr(_resolve_client(state, ctx).api, "prompts"):
+                    prompt_obj = _prompts_get(_resolve_client(state, ctx).api.prompts, name=name, version=version)
                 else:
                     prompt_obj = None
             except Exception as exc:
@@ -2932,10 +2994,10 @@ async def update_prompt_labels(
                 return None
 
         updated_prompt = None
-        if hasattr(state.langfuse_client, "update_prompt"):
-            updated_prompt = _try_update(state.langfuse_client.update_prompt)
-        elif hasattr(state.langfuse_client, "api"):
-            api = state.langfuse_client.api
+        if hasattr(_resolve_client(state, ctx), "update_prompt"):
+            updated_prompt = _try_update(_resolve_client(state, ctx).update_prompt)
+        elif hasattr(_resolve_client(state, ctx), "api"):
+            api = _resolve_client(state, ctx).api
             for attr in ("prompt_version", "promptVersion", "prompt_versions", "promptVersions"):
                 if not hasattr(api, attr):
                     continue
@@ -2996,7 +3058,7 @@ async def list_datasets(
         page = _normalize_field_default(page) or 1
         limit = _normalize_field_default(limit) or 50
 
-        response = state.langfuse_client.api.datasets.list(page=page, limit=limit)
+        response = _resolve_client(state, ctx).api.datasets.list(page=page, limit=limit)
 
         items, pagination = _extract_items_from_response(response)
         raw_datasets = [_sdk_object_to_python(d) for d in items]
@@ -3056,7 +3118,7 @@ async def get_dataset(
     state = cast(MCPState, ctx.request_context.lifespan_context)
 
     try:
-        dataset = state.langfuse_client.api.datasets.get(dataset_name=name)
+        dataset = _resolve_client(state, ctx).api.datasets.get(dataset_name=name)
 
         if dataset is None:
             raise LookupError(f"Dataset '{name}' not found")
@@ -3124,7 +3186,7 @@ async def list_dataset_items(
         if source_observation_id:
             api_kwargs["source_observation_id"] = source_observation_id
 
-        response = state.langfuse_client.api.dataset_items.list(**api_kwargs)
+        response = _resolve_client(state, ctx).api.dataset_items.list(**api_kwargs)
 
         items, pagination = _extract_items_from_response(response)
         raw_items = [_sdk_object_to_python(item) for item in items]
@@ -3189,7 +3251,7 @@ async def get_dataset_item(
     state = cast(MCPState, ctx.request_context.lifespan_context)
 
     try:
-        item = state.langfuse_client.api.dataset_items.get(id=item_id)
+        item = _resolve_client(state, ctx).api.dataset_items.get(id=item_id)
 
         if item is None:
             raise LookupError(f"Dataset item '{item_id}' not found")
@@ -3258,9 +3320,9 @@ async def create_dataset(
         # Both supported SDKs (v3 ≥3.11.2, v4 ≥4.0.0) expose the top-level
         # ``Langfuse.create_dataset`` shortcut, so we don't ship a v3/v4 fallback
         # for ``api.datasets.create`` that would never run in practice.
-        if not hasattr(state.langfuse_client, "create_dataset"):
+        if not hasattr(_resolve_client(state, ctx), "create_dataset"):
             raise RuntimeError("Unsupported Langfuse client: missing top-level create_dataset() shortcut")
-        dataset = state.langfuse_client.create_dataset(**kwargs)
+        dataset = _resolve_client(state, ctx).create_dataset(**kwargs)
 
         result = _sdk_object_to_python(dataset)
 
@@ -3337,9 +3399,9 @@ async def create_dataset_item(
         # As with create_dataset above, both supported SDKs expose the top-level
         # ``Langfuse.create_dataset_item`` shortcut, so the api-level fallback
         # would never run for any supported client.
-        if not hasattr(state.langfuse_client, "create_dataset_item"):
+        if not hasattr(_resolve_client(state, ctx), "create_dataset_item"):
             raise RuntimeError("Unsupported Langfuse client: missing top-level create_dataset_item() shortcut")
-        item = state.langfuse_client.create_dataset_item(**kwargs)
+        item = _resolve_client(state, ctx).create_dataset_item(**kwargs)
 
         result = _sdk_object_to_python(item)
 
@@ -3373,7 +3435,7 @@ async def delete_dataset_item(
     state = cast(MCPState, ctx.request_context.lifespan_context)
 
     try:
-        response = state.langfuse_client.api.dataset_items.delete(id=item_id)
+        response = _resolve_client(state, ctx).api.dataset_items.delete(id=item_id)
 
         result = _sdk_object_to_python(response) if response else {}
 
@@ -3405,7 +3467,7 @@ async def list_annotation_queues(
         page = _normalize_field_default(page) or 1
         limit = _normalize_field_default(limit) or 50
 
-        response = state.langfuse_client.api.annotation_queues.list_queues(page=page, limit=limit)
+        response = _resolve_client(state, ctx).api.annotation_queues.list_queues(page=page, limit=limit)
         items, pagination = _extract_items_from_response(response)
         queues = [_sdk_object_to_python(item) for item in items]
         logger.info(f"Listed {len(queues)} annotation queues (page={page}, limit={limit})")
@@ -3434,7 +3496,7 @@ async def create_annotation_queue(
         # don't leak through to the SDK call.
         score_config_ids = _normalize_field_default(score_config_ids) or []
 
-        method = state.langfuse_client.api.annotation_queues.create_queue
+        method = _resolve_client(state, ctx).api.annotation_queues.create_queue
         queue = _compat.call_with_request_or_kwargs(
             method,
             lambda: _build_create_annotation_queue_request(name=name, description=description, score_config_ids=score_config_ids),
@@ -3457,7 +3519,7 @@ async def get_annotation_queue(
     """Get a single annotation queue by ID."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        queue = state.langfuse_client.api.annotation_queues.get_queue(queue_id=queue_id)
+        queue = _resolve_client(state, ctx).api.annotation_queues.get_queue(queue_id=queue_id)
         result = _sdk_object_to_python(queue)
         if not result:
             raise LookupError(f"Annotation queue '{queue_id}' not found")
@@ -3480,7 +3542,7 @@ async def list_annotation_queue_items(
         page = _normalize_field_default(page) or 1
         limit = _normalize_field_default(limit) or 50
 
-        response = state.langfuse_client.api.annotation_queues.list_queue_items(queue_id=queue_id, page=page, limit=limit)
+        response = _resolve_client(state, ctx).api.annotation_queues.list_queue_items(queue_id=queue_id, page=page, limit=limit)
         items, pagination = _extract_items_from_response(response)
         queue_items = [_sdk_object_to_python(item) for item in items]
         logger.info(f"Listed {len(queue_items)} items from annotation queue '{queue_id}'")
@@ -3507,7 +3569,7 @@ async def get_annotation_queue_item(
     """Get a specific annotation queue item by queue and item ID."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        item = state.langfuse_client.api.annotation_queues.get_queue_item(queue_id=queue_id, item_id=item_id)
+        item = _resolve_client(state, ctx).api.annotation_queues.get_queue_item(queue_id=queue_id, item_id=item_id)
         result = _sdk_object_to_python(item)
         if not result:
             raise LookupError(f"Annotation queue item '{item_id}' not found in queue '{queue_id}'")
@@ -3533,7 +3595,7 @@ async def create_annotation_queue_item(
         if status is not None:
             body_kwargs["status"] = status
 
-        method = state.langfuse_client.api.annotation_queues.create_queue_item
+        method = _resolve_client(state, ctx).api.annotation_queues.create_queue_item
         item = _compat.call_with_request_or_kwargs(
             method,
             lambda: _build_create_annotation_queue_item_request(**body_kwargs),
@@ -3557,7 +3619,7 @@ async def update_annotation_queue_item(
     """Update the status of an annotation queue item."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        method = state.langfuse_client.api.annotation_queues.update_queue_item
+        method = _resolve_client(state, ctx).api.annotation_queues.update_queue_item
         item = _compat.call_with_request_or_kwargs(
             method,
             lambda: _build_update_annotation_queue_item_request(status=status),
@@ -3580,7 +3642,7 @@ async def delete_annotation_queue_item(
     """Delete an annotation queue item."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        response = state.langfuse_client.api.annotation_queues.delete_queue_item(queue_id=queue_id, item_id=item_id)
+        response = _resolve_client(state, ctx).api.annotation_queues.delete_queue_item(queue_id=queue_id, item_id=item_id)
         result = _sdk_object_to_python(response) if response else {}
         logger.info(f"Deleted annotation queue item '{item_id}' in queue '{queue_id}'")
         return {"data": result, "metadata": {"deleted": True, "queue_id": queue_id, "item_id": item_id}}
@@ -3633,7 +3695,7 @@ async def create_annotation_queue_assignment(
     """Assign a user to an annotation queue."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        method = state.langfuse_client.api.annotation_queues.create_queue_assignment
+        method = _resolve_client(state, ctx).api.annotation_queues.create_queue_assignment
         response = _compat.call_with_request_or_kwargs(
             method,
             lambda: _build_annotation_queue_assignment_request(user_id),
@@ -3656,7 +3718,7 @@ async def delete_annotation_queue_assignment(
     """Unassign a user from an annotation queue."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        method = state.langfuse_client.api.annotation_queues.delete_queue_assignment
+        method = _resolve_client(state, ctx).api.annotation_queues.delete_queue_assignment
         response = _compat.call_with_request_or_kwargs(
             method,
             lambda: _build_annotation_queue_assignment_request(user_id),
@@ -3740,7 +3802,7 @@ async def list_scores_v2(
         }
         api_kwargs = {k: v for k, v in api_kwargs.items() if v is not None}
 
-        scores_namespace = _compat.get_score_namespace(state.langfuse_client)
+        scores_namespace = _compat.get_score_namespace(_resolve_client(state, ctx))
         if scores_namespace is None:
             raise RuntimeError("Unsupported Langfuse client: no scores namespace exposed")
         list_method = _compat.get_score_list_method(scores_namespace)
@@ -3772,7 +3834,7 @@ async def get_score_v2(
     """Get a score by ID from the scores API (v3 ``score_v_2`` or v4 ``scores``)."""
     state = cast(MCPState, ctx.request_context.lifespan_context)
     try:
-        scores_namespace = _compat.get_score_namespace(state.langfuse_client)
+        scores_namespace = _compat.get_score_namespace(_resolve_client(state, ctx))
         if scores_namespace is None or not hasattr(scores_namespace, "get_by_id"):
             raise RuntimeError("Unsupported Langfuse client: no get_by_id method on scores namespace")
         score = scores_namespace.get_by_id(score_id=score_id)
@@ -3787,8 +3849,8 @@ async def get_score_v2(
 
 
 def app_factory(
-    public_key: str,
-    secret_key: str,
+    public_key: str | None,
+    secret_key: str | None,
     host: str,
     cache_size: int = 100,
     dump_dir: str | None = None,
@@ -3796,6 +3858,8 @@ def app_factory(
     timeout: int = 30,
     read_only: bool = False,
     default_output_mode: OutputMode = OutputMode.COMPACT,
+    bind_host: str = "0.0.0.0",
+    port: int = 8000,
 ) -> FastMCP:
     """Create a FastMCP server with Langfuse tools.
 
@@ -3820,22 +3884,27 @@ def app_factory(
 
     @asynccontextmanager
     async def lifespan(server: FastMCP) -> AsyncIterator[MCPState]:
-        init_params = inspect.signature(Langfuse.__init__).parameters
-        langfuse_kwargs = {
-            "public_key": public_key,
-            "secret_key": secret_key,
-            "host": host,
-            "debug": False,
-            "flush_at": 0,
-            "flush_interval": None,
-        }
-        if "timeout" in init_params:
-            langfuse_kwargs["timeout"] = timeout
-        if "tracing_enabled" in init_params:
-            langfuse_kwargs["tracing_enabled"] = False
+        default_client: Langfuse | None = None
+        if public_key and secret_key:
+            init_params = inspect.signature(Langfuse.__init__).parameters
+            langfuse_kwargs: dict[str, Any] = {
+                "public_key": public_key,
+                "secret_key": secret_key,
+                "host": host,
+                "debug": False,
+                "flush_at": 0,
+                "flush_interval": None,
+            }
+            if "timeout" in init_params:
+                langfuse_kwargs["timeout"] = timeout
+            if "tracing_enabled" in init_params:
+                langfuse_kwargs["tracing_enabled"] = False
+            default_client = Langfuse(**langfuse_kwargs)
 
         state = MCPState(
-            langfuse_client=Langfuse(**langfuse_kwargs),
+            langfuse_client=default_client,
+            host=host,
+            timeout=timeout,
             observation_cache=LRUCache(maxsize=cache_size),
             file_to_observations_map=LRUCache(maxsize=cache_size),
             exception_type_map=LRUCache(maxsize=cache_size),
@@ -3846,11 +3915,18 @@ def app_factory(
         try:
             yield state
         finally:
-            logger.info("Cleaning up Langfuse client")
-            state.langfuse_client.flush()
-            state.langfuse_client.shutdown()
+            logger.info("Cleaning up Langfuse clients")
+            all_clients = list(state.project_clients.values())
+            if state.langfuse_client is not None:
+                all_clients.append(state.langfuse_client)
+            for client in all_clients:
+                try:
+                    client.flush()
+                    client.shutdown()
+                except Exception as e:
+                    logger.warning(f"Error shutting down Langfuse client: {e}")
 
-    mcp = FastMCP("Langfuse MCP Server", lifespan=lifespan)
+    mcp = FastMCP("Langfuse MCP Server", lifespan=lifespan, host=bind_host, port=port)
 
     # Tool function lookup
     tool_funcs = {
@@ -3969,9 +4045,15 @@ def main():
         timeout=args.timeout,
         read_only=args.read_only,
         default_output_mode=_ensure_output_mode(args.default_output_mode),
+        bind_host=args.bind_host,
+        port=args.port,
     )
 
-    app.run(transport="stdio")
+    if args.transport == "streamable-http":
+        logger.info(f"Starting HTTP transport on {args.bind_host}:{args.port}")
+        app.run(transport="streamable-http")
+    else:
+        app.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -429,8 +429,13 @@ def _build_arg_parser(env_defaults: dict[str, Any]) -> argparse.ArgumentParser:
     parser.add_argument(
         "--bind-host",
         type=str,
-        default=os.getenv("LANGFUSE_MCP_BIND_HOST", "0.0.0.0"),
-        help="Bind address for HTTP transport (default: 0.0.0.0). Set via LANGFUSE_MCP_BIND_HOST.",
+        default=os.getenv("LANGFUSE_MCP_BIND_HOST", "127.0.0.1"),
+        help=(
+            "Bind address for HTTP transport (default: 127.0.0.1, localhost only). "
+            "Use 0.0.0.0 to expose on all interfaces — only do this behind an "
+            "authenticating reverse-proxy or within a trusted network. "
+            "Set via LANGFUSE_MCP_BIND_HOST."
+        ),
     )
 
     return parser
@@ -1049,6 +1054,29 @@ def process_data_with_mode(
     return process_compact_data(data), None
 
 
+_MAX_PROJECT_CLIENTS = 32  # Maximum number of per-request Langfuse clients to cache.
+
+
+class _BoundedClientCache(LRUCache):
+    """LRU cache for Langfuse clients that flushes and shuts down evicted entries.
+
+    When the cache is full and a new client must be inserted, ``cachetools``
+    calls :meth:`popitem` to evict the least-recently-used entry before
+    inserting the new one.  We override that hook to cleanly close the evicted
+    ``Langfuse`` client so file-handles and background threads are not leaked.
+    """
+
+    def popitem(self) -> tuple[tuple[str, str], "Langfuse"]:
+        """Remove the LRU client, flush and shut it down, then return the pair."""
+        key, client = super().popitem()
+        try:
+            client.flush()
+            client.shutdown()
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Error closing evicted Langfuse client for key=%s…: %s", key[0][:8], exc)
+        return key, client
+
+
 @dataclass
 class MCPState:
     """State object passed from lifespan context to tools.
@@ -1060,8 +1088,11 @@ class MCPState:
     langfuse_client: Langfuse | None
     host: str = "https://cloud.langfuse.com"
     timeout: int = 30
-    # Per-request project clients keyed by (public_key, secret_key)
-    project_clients: dict[tuple[str, str], Langfuse] = field(default_factory=dict)
+    # Per-request project clients keyed by (public_key, secret_key); bounded to prevent
+    # unbounded growth from arbitrary caller-supplied header pairs.
+    project_clients: _BoundedClientCache = field(
+        default_factory=lambda: _BoundedClientCache(maxsize=_MAX_PROJECT_CLIENTS)
+    )
     # LRU caches for efficient exception lookup
     observation_cache: LRUCache = field(
         default_factory=lambda: LRUCache(maxsize=100), metadata={"description": "Cache for observations to reduce API calls"}
@@ -3858,7 +3889,7 @@ def app_factory(
     timeout: int = 30,
     read_only: bool = False,
     default_output_mode: OutputMode = OutputMode.COMPACT,
-    bind_host: str = "0.0.0.0",
+    bind_host: str = "127.0.0.1",
     port: int = 8000,
 ) -> FastMCP:
     """Create a FastMCP server with Langfuse tools.
@@ -3874,7 +3905,8 @@ def app_factory(
         timeout: API request timeout in seconds (default: 30). The Langfuse SDK defaults to 5s which is too aggressive.
         read_only: If True, disable all write operations (create/update/delete tools).
         default_output_mode: Default output_mode exposed in MCP tool schemas.
-        bind_host: Bind address for HTTP transport (default: 0.0.0.0).
+        bind_host: Bind address for HTTP transport (default: 127.0.0.1, localhost only).
+            Use 0.0.0.0 only behind an authenticating reverse-proxy or trusted network.
         port: Port for HTTP transport (default: 8000).
     """
     if enabled_tools is None:

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -347,14 +347,14 @@ def _build_arg_parser(env_defaults: dict[str, Any]) -> argparse.ArgumentParser:
         type=str,
         default=env_defaults["public_key"],
         required=False,
-        help="Langfuse public key (optional if provided via x-langfuse-public-key HTTP header)",
+        help="Langfuse public key (optional if provided via Authorization: Basic <base64(public_key:secret_key)> HTTP header)",
     )
     parser.add_argument(
         "--secret-key",
         type=str,
         default=env_defaults["secret_key"],
         required=False,
-        help="Langfuse secret key (optional if provided via x-langfuse-secret-key HTTP header)",
+        help="Langfuse secret key (optional if provided via Authorization: Basic <base64(public_key:secret_key)> HTTP header)",
     )
     parser.add_argument("--host", type=str, default=env_defaults["host"], help="Langfuse host URL")
     parser.add_argument(

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -3874,6 +3874,8 @@ def app_factory(
         timeout: API request timeout in seconds (default: 30). The Langfuse SDK defaults to 5s which is too aggressive.
         read_only: If True, disable all write operations (create/update/delete tools).
         default_output_mode: Default output_mode exposed in MCP tool schemas.
+        bind_host: Bind address for HTTP transport (default: 0.0.0.0).
+        port: Port for HTTP transport (default: 8000).
     """
     if enabled_tools is None:
         enabled_tools = ALL_TOOL_GROUPS

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -1091,9 +1091,7 @@ class MCPState:
     timeout: int = 30
     # Per-request project clients keyed by (public_key, secret_key); bounded to prevent
     # unbounded growth from arbitrary caller-supplied header pairs.
-    project_clients: _BoundedClientCache = field(
-        default_factory=lambda: _BoundedClientCache(maxsize=_MAX_PROJECT_CLIENTS)
-    )
+    project_clients: _BoundedClientCache = field(default_factory=lambda: _BoundedClientCache(maxsize=_MAX_PROJECT_CLIENTS))
     # LRU caches for efficient exception lookup
     observation_cache: LRUCache = field(
         default_factory=lambda: LRUCache(maxsize=100), metadata={"description": "Cache for observations to reduce API calls"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,17 +47,9 @@ def patch_dependencies(monkeypatch: pytest.MonkeyPatch):
     sys.modules.setdefault("mcp.server", server_pkg)
     sys.modules.setdefault("mcp.server.fastmcp", fastmcp_mod)
 
-    # Minimal cachetools with an LRUCache placeholder so that `langfuse_mcp` can
-    # import it without requiring the real dependency.
-    cachetools_mod = types.ModuleType("cachetools")
-
-    class LRUCache(dict):
-        def __init__(self, maxsize=128) -> None:
-            super().__init__()
-            self.maxsize = maxsize
-
-    cachetools_mod.LRUCache = LRUCache
-    sys.modules.setdefault("cachetools", cachetools_mod)
+    # `cachetools` is a declared project dependency: no stub needed.  Installing a
+    # plain-dict stub here would silently disable maxsize enforcement and break the
+    # _BoundedClientCache tests.  The real library is always available in the dev env.
 
     # Provide a minimal stub of the `pydantic` module with BaseModel and Field
     # used only for type hints within `langfuse_mcp`.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -61,8 +61,8 @@ def test_max_age_days_env_override(monkeypatch):
         importlib.reload(main_module)
 
 
-def test_cli_requires_keys_without_env(monkeypatch):
-    """Missing env and args should keep credentials required."""
+def test_cli_accepts_no_keys_without_env(monkeypatch):
+    """Keys are optional — credentials can be supplied per-request via HTTP headers."""
     monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
     monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
     monkeypatch.delenv("LANGFUSE_LOG_LEVEL", raising=False)
@@ -72,8 +72,9 @@ def test_cli_requires_keys_without_env(monkeypatch):
     from langfuse_mcp.__main__ import _build_arg_parser, _read_env_defaults
 
     parser = _build_arg_parser(_read_env_defaults())
-    with pytest.raises(SystemExit):
-        parser.parse_args([])
+    args = parser.parse_args([])
+    assert args.public_key is None
+    assert args.secret_key is None
 
 
 def test_package_importable():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -279,6 +279,4 @@ class TestParseBasicAuth:
         for header in cases:
             with pytest.raises(ValueError) as exc_info:
                 _parse_basic_auth(header)
-            assert secret not in str(exc_info.value), (
-                f"Secret leaked into error message for header={header!r}"
-            )
+            assert secret not in str(exc_info.value), f"Secret leaked into error message for header={header!r}"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -187,3 +187,98 @@ def test_bind_host_default_is_localhost(monkeypatch):
     parser = _build_arg_parser(_read_env_defaults())
     args = parser.parse_args([])
     assert args.bind_host == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_basic_auth
+# ---------------------------------------------------------------------------
+
+
+class TestParseBasicAuth:
+    """Tests for Authorization: Basic header parsing."""
+
+    def _encode(self, value: str) -> str:
+        import base64
+
+        return base64.b64encode(value.encode()).decode()
+
+    def test_valid_credentials(self):
+        """Valid base64(pk:sk) must return (pk, sk)."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        pk, sk = _parse_basic_auth(f"Basic {self._encode('pk-lf-abc:sk-lf-xyz')}")
+        assert pk == "pk-lf-abc"
+        assert sk == "sk-lf-xyz"
+
+    def test_case_insensitive_scheme(self):
+        """Scheme matching must be case-insensitive (BASIC / basic / Basic)."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        pk, sk = _parse_basic_auth(f"BASIC {self._encode('pk:sk')}")
+        assert pk == "pk"
+        assert sk == "sk"
+
+    def test_secret_with_colon(self):
+        """A colon inside the secret_key must be preserved."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        pk, sk = _parse_basic_auth(f"Basic {self._encode('pk-lf-abc:sk:with:colons')}")
+        assert pk == "pk-lf-abc"
+        assert sk == "sk:with:colons"
+
+    def test_wrong_scheme_raises(self):
+        """Bearer or any non-Basic scheme must be rejected."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        with pytest.raises(ValueError, match="scheme"):
+            _parse_basic_auth(f"Bearer {self._encode('pk:sk')}")
+
+    def test_invalid_base64_raises(self):
+        """Non-base64 credentials must raise ValueError."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        with pytest.raises(ValueError, match="base64"):
+            _parse_basic_auth("Basic not-valid-base64!!!")
+
+    def test_missing_colon_raises(self):
+        """Credentials without a colon separator must be rejected."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        with pytest.raises(ValueError, match="public_key:secret_key"):
+            _parse_basic_auth(f"Basic {self._encode('nocolon')}")
+
+    def test_empty_public_key_raises(self):
+        """Empty public_key (leading colon) must be rejected."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        with pytest.raises(ValueError, match="public_key"):
+            _parse_basic_auth(f"Basic {self._encode(':sk-lf-xyz')}")
+
+    def test_empty_secret_key_raises(self):
+        """Empty secret_key (trailing colon) must be rejected."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        with pytest.raises(ValueError, match="secret_key"):
+            _parse_basic_auth(f"Basic {self._encode('pk-lf-abc:')}")
+
+    def test_empty_credentials_field_raises(self):
+        """Whitespace-only credentials field must be rejected."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        with pytest.raises(ValueError, match="missing credentials"):
+            _parse_basic_auth("Basic ")
+
+    def test_secret_never_appears_in_error_message(self):
+        """The secret must not leak into any ValueError message."""
+        from langfuse_mcp.__main__ import _parse_basic_auth
+
+        secret = "super-secret-value-abc123"
+        cases = [
+            f"Bearer {self._encode(f'pk:{secret}')}",  # wrong scheme
+        ]
+        for header in cases:
+            with pytest.raises(ValueError) as exc_info:
+                _parse_basic_auth(header)
+            assert secret not in str(exc_info.value), (
+                f"Secret leaked into error message for header={header!r}"
+            )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import os
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -105,3 +106,84 @@ def test_python_version():
     python_version = sys.version_info
     assert python_version.major == 3
     assert python_version.minor >= 10, f"Python version {python_version.major}.{python_version.minor} is not supported"
+
+
+# ---------------------------------------------------------------------------
+# _BoundedClientCache
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedClientCache:
+    """Tests for the bounded LRU cache used to hold per-request Langfuse clients."""
+
+    def _make_cache(self, maxsize: int = 2):
+        from langfuse_mcp.__main__ import _BoundedClientCache
+
+        return _BoundedClientCache(maxsize=maxsize)
+
+    def test_never_exceeds_maxsize(self):
+        """Cache length must never exceed maxsize regardless of insertion count."""
+        maxsize = 5
+        cache = self._make_cache(maxsize)
+        for i in range(maxsize + 10):
+            cache[(f"pk_{i}", f"sk_{i}")] = MagicMock()
+        assert len(cache) <= maxsize
+
+    def test_lru_eviction_flushes_and_shuts_down_client(self):
+        """The LRU client must be flushed and shut down when it is evicted."""
+        cache = self._make_cache(maxsize=2)
+        client_a = MagicMock()
+        client_b = MagicMock()
+        client_c = MagicMock()
+
+        cache[("pk_a", "sk_a")] = client_a
+        cache[("pk_b", "sk_b")] = client_b
+        # Access client_a to promote it — client_b becomes LRU
+        _ = cache[("pk_a", "sk_a")]
+        # Inserting client_c must evict client_b (LRU)
+        cache[("pk_c", "sk_c")] = client_c
+
+        client_b.flush.assert_called_once()
+        client_b.shutdown.assert_called_once()
+        # client_a and client_c must not be touched
+        client_a.flush.assert_not_called()
+        client_c.flush.assert_not_called()
+
+    def test_evicted_key_removed_from_cache(self):
+        """After eviction the key must no longer be present in the cache."""
+        cache = self._make_cache(maxsize=2)
+        cache[("pk_a", "sk_a")] = MagicMock()
+        cache[("pk_b", "sk_b")] = MagicMock()
+        # Access a so b is LRU; inserting c evicts b
+        _ = cache[("pk_a", "sk_a")]
+        cache[("pk_c", "sk_c")] = MagicMock()
+
+        assert ("pk_b", "sk_b") not in cache
+        assert ("pk_a", "sk_a") in cache
+        assert ("pk_c", "sk_c") in cache
+
+    def test_no_eviction_below_maxsize(self):
+        """Clients must not be flushed or shut down before the cache is full."""
+        cache = self._make_cache(maxsize=3)
+        clients = [MagicMock() for _ in range(3)]
+        for i, client in enumerate(clients):
+            cache[(f"pk_{i}", f"sk_{i}")] = client
+
+        for client in clients:
+            client.flush.assert_not_called()
+            client.shutdown.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# bind_host default
+# ---------------------------------------------------------------------------
+
+
+def test_bind_host_default_is_localhost(monkeypatch):
+    """--bind-host must default to 127.0.0.1, not 0.0.0.0."""
+    monkeypatch.delenv("LANGFUSE_MCP_BIND_HOST", raising=False)
+    from langfuse_mcp.__main__ import _build_arg_parser, _read_env_defaults
+
+    parser = _build_arg_parser(_read_env_defaults())
+    args = parser.parse_args([])
+    assert args.bind_host == "127.0.0.1"


### PR DESCRIPTION
## Summary

Add multi-project support for self-hosted deployments. Previously each Langfuse project required a separate server instance. Now one server can handle multiple projects by accepting per-request credentials through the standard `Authorization: Basic <base64(public_key:secret_key)>` HTTP header, making it practical to run a single Docker container for an organization or shared environment.

## Changes

- `--public-key` and `--secret-key` CLI flags are now optional at startup for HTTP deployments.
- Added `--transport` (`stdio` / `streamable-http`), `--port`, and `--bind-host` flags for HTTP mode.
- Added `_resolve_client()` to read `Authorization: Basic` credentials from incoming HTTP requests, create a per-project Langfuse client, and cache it by key pair.
- Added bounded per-project client caching with cleanup for evicted clients.
- MCP state now tracks host, timeout, and per-project clients; `langfuse_client` can be `None` when no startup default credentials are configured.
- Tool handlers resolve credentials through `_resolve_client(state, ctx)` instead of accessing `state.langfuse_client` directly.
- Graceful shutdown flushes and shuts down all cached project clients.
- Updated docs and tests for HTTP transport, Basic auth, localhost default binding, and bounded cache behavior.

## Testing

- [ ] Lint passes (`ruff check . && ruff format --check .`)
- [ ] Type check passes (`pyright langfuse_mcp/`)
- [ ] Tests pass (`pytest -v`)
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if applicable)

## Related Issues

Closes #48

Note: this PR ships per-request credentials via the standard `Authorization: Basic <base64(public_key:secret_key)>` header, not the earlier `x-langfuse-public-key` / `x-langfuse-secret-key` custom-header sketch from #48. The stdio `--profile` path remains tracked separately in #54 and is out of scope here.
