### PR TITLE
fix: preserve trace fields scoping on sdk floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   megabytes — which is the main cause of read timeouts. `fetch_trace` now drops the
   `observations` field group unless `include_observations=True` (so `include_observations=False`
   no longer returns observation references), and raises the per-request read timeout for
-  the heavy `include_observations=True` path. Falls back to a plain `get()` on older SDKs
-  that do not accept `request_options`.
+  single-trace fetches. The `fields` selector is forwarded through SDK request options so
+  it works on the supported `langfuse>=3.11.2` floor. Falls back to a plain `get()` only
+  on older SDKs that do not accept `request_options`.
 
 ## [0.9.1] - 2026-05-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   credentials; any malformed value is rejected (fail closed — no silent fallback).
   Per-project clients are cached in a bounded LRU (max 32 entries); evicted clients
   are flushed and shut down to prevent resource leaks.
+- **`LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS`** (default `120`): per-request read timeout
+  in seconds for single-trace fetches (`fetch_trace`). Raise it if large traces with
+  `include_observations=True` time out.
+
+### Changed
+- **`fetch_trace` scopes the `GET /traces/{id}` request via a `fields` selector.** The
+  endpoint returns every field group by default (`core,io,scores,observations,metrics`);
+  for traces with many observations that pulls each observation's full IO — often
+  megabytes — which is the main cause of read timeouts. `fetch_trace` now drops the
+  `observations` field group unless `include_observations=True` (so `include_observations=False`
+  no longer returns observation references), and raises the per-request read timeout for
+  the heavy `include_observations=True` path. Falls back to a plain `get()` on older SDKs
+  that do not accept `request_options`.
 
 ## [0.9.1] - 2026-05-06
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ uv run -m ruff check --fix .
 - `LANGFUSE_MCP_LOG_FILE` defaults to `/tmp/langfuse_mcp.log`
 - `LANGFUSE_MCP_TOOLS` selects comma-separated tool groups
 - `LANGFUSE_MCP_DEFAULT_OUTPUT_MODE` sets the default MCP tool `output_mode`
+- `LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS` sets the per-request read timeout (seconds) for single-trace fetches (`fetch_trace`); defaults to `120`
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ silent fallback to a different project.
 | Variable | Default | Description |
 |---|---|---|
 | `LANGFUSE_MAX_AGE_DAYS` | `7` | Caps the lookback window for time-based tools (`fetch_traces`, `fetch_observations`, etc.). Set to match your Langfuse instance's data retention — e.g. `30` if your retention is 30 days. |
+| `LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS` | `120` | Per-request read timeout (seconds) for single-trace fetches (`fetch_trace`). Raise it if large traces with `include_observations=True` time out. Must be a positive integer. |
 
 ## Development
 

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -827,15 +827,14 @@ def _get_trace(langfuse_client: Any, trace_id: str, include_observations: bool) 
     megabytes — even when the caller only wants an overview. That payload is the
     main cause of read timeouts on this tool.
 
-    The SDK's ``trace.get()`` has no ``fields`` parameter, but the server accepts a
-    ``fields`` query param and the Fern client forwards anything passed through
-    ``request_options.additional_query_parameters``. So we scope the request:
-    drop the ``observations`` field group unless observations were explicitly asked
-    for, which skips the expensive per-observation IO entirely. We also raise the
-    per-request read timeout for the heavy ``include_observations=True`` case.
+    The SDK's ``trace.get()`` accepts a first-class ``fields`` selector (forwarded as
+    the ``fields`` query param the API supports), so we scope the request: drop the
+    ``observations`` field group unless observations were explicitly asked for, which
+    skips the expensive per-observation IO entirely. We also raise the per-request
+    read timeout for the heavy ``include_observations=True`` case via ``request_options``.
 
-    Falls back to a plain ``get()`` for older SDKs that do not accept
-    ``request_options`` (or ``additional_query_parameters``).
+    Falls back to a plain ``get()`` for older SDKs whose ``trace.get()`` predates the
+    ``fields``/``request_options`` parameters.
     """
     if not hasattr(langfuse_client, "api") or not hasattr(langfuse_client.api, "trace"):
         raise RuntimeError("Unsupported Langfuse client: no trace getter available")
@@ -843,14 +842,11 @@ def _get_trace(langfuse_client: Any, trace_id: str, include_observations: bool) 
     # Note: the endpoint has no "observations without IO" mode — including the
     # observations group always brings their full IO — so we toggle the whole group.
     fields = "core,io,scores,observations,metrics" if include_observations else "core,io,scores,metrics"
-    request_options = {
-        "additional_query_parameters": {"fields": fields},
-        "timeout_in_seconds": TRACE_GET_TIMEOUT_SECONDS,
-    }
+    request_options = {"timeout_in_seconds": TRACE_GET_TIMEOUT_SECONDS}
     try:
-        return langfuse_client.api.trace.get(trace_id=trace_id, request_options=request_options)
+        return langfuse_client.api.trace.get(trace_id=trace_id, fields=fields, request_options=request_options)
     except TypeError:
-        # Older SDK without request_options support: fall back to a plain get().
+        # Older SDK whose trace.get() lacks fields/request_options: fall back to a plain get().
         return langfuse_client.api.trace.get(trace_id=trace_id)
 
 

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -827,14 +827,15 @@ def _get_trace(langfuse_client: Any, trace_id: str, include_observations: bool) 
     megabytes — even when the caller only wants an overview. That payload is the
     main cause of read timeouts on this tool.
 
-    The SDK's ``trace.get()`` accepts a first-class ``fields`` selector (forwarded as
-    the ``fields`` query param the API supports), so we scope the request: drop the
-    ``observations`` field group unless observations were explicitly asked for, which
-    skips the expensive per-observation IO entirely. We also raise the per-request
-    read timeout for the heavy ``include_observations=True`` case via ``request_options``.
+    The endpoint supports a ``fields`` query param, but the supported SDK floor
+    does not expose it as a first-class ``trace.get()`` argument. We pass it through
+    ``request_options.additional_query_parameters`` instead: drop the
+    ``observations`` field group unless observations were explicitly asked for,
+    which skips the expensive per-observation IO entirely. We also raise the
+    per-request read timeout via the same request options.
 
-    Falls back to a plain ``get()`` for older SDKs whose ``trace.get()`` predates the
-    ``fields``/``request_options`` parameters.
+    Falls back to a plain ``get()`` for older SDKs whose ``trace.get()`` predates
+    ``request_options`` entirely.
     """
     if not hasattr(langfuse_client, "api") or not hasattr(langfuse_client.api, "trace"):
         raise RuntimeError("Unsupported Langfuse client: no trace getter available")
@@ -842,11 +843,14 @@ def _get_trace(langfuse_client: Any, trace_id: str, include_observations: bool) 
     # Note: the endpoint has no "observations without IO" mode — including the
     # observations group always brings their full IO — so we toggle the whole group.
     fields = "core,io,scores,observations,metrics" if include_observations else "core,io,scores,metrics"
-    request_options = {"timeout_in_seconds": TRACE_GET_TIMEOUT_SECONDS}
+    request_options = {
+        "additional_query_parameters": {"fields": fields},
+        "timeout_in_seconds": TRACE_GET_TIMEOUT_SECONDS,
+    }
     try:
-        return langfuse_client.api.trace.get(trace_id=trace_id, fields=fields, request_options=request_options)
+        return langfuse_client.api.trace.get(trace_id=trace_id, request_options=request_options)
     except TypeError:
-        # Older SDK whose trace.get() lacks fields/request_options: fall back to a plain get().
+        # Older SDK without request_options support: fall back to a plain get().
         return langfuse_client.api.trace.get(trace_id=trace_id)
 
 

--- a/langfuse_mcp/__main__.py
+++ b/langfuse_mcp/__main__.py
@@ -112,6 +112,28 @@ MAX_FIELD_LENGTH = 500  # Maximum string length for field values
 MAX_RESPONSE_SIZE = 20000  # Maximum size of response object in characters
 TRUNCATE_SUFFIX = "..."  # Suffix to add to truncated fields
 
+
+def _read_trace_get_timeout_seconds() -> int:
+    """Read the per-request read timeout for single-trace fetches.
+
+    A single trace with many observations can take far longer than the default
+    client timeout (``LANGFUSE_TIMEOUT``, 30s) to download. This override applies
+    only to ``GET /traces/{id}`` so the heavier ``include_observations=True`` path
+    does not hit a premature read timeout. Override via
+    ``LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS``.
+    """
+    raw_value = os.environ.get("LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS", "120")
+    try:
+        timeout_seconds = int(raw_value)
+    except ValueError as exc:
+        raise ValueError("LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS must be an integer number of seconds") from exc
+    if timeout_seconds <= 0:
+        raise ValueError("LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS must be a positive integer")
+    return timeout_seconds
+
+
+TRACE_GET_TIMEOUT_SECONDS = _read_trace_get_timeout_seconds()
+
 # Tool groups for selective loading (reduces token overhead)
 TOOL_GROUPS = {
     "traces": ["fetch_traces", "fetch_trace"],
@@ -799,13 +821,37 @@ def _count_by_key(decisions: list[dict[str, Any]], key: str) -> dict[str, int]:
 def _get_trace(langfuse_client: Any, trace_id: str, include_observations: bool) -> Any:
     """Fetch a single trace handling SDK version differences.
 
-    Note: Some Langfuse SDK versions do not support a `fields` selector on `get()`. We avoid
-    passing `fields` here and rely on embedding observations separately when requested.
+    The public ``GET /traces/{id}`` endpoint returns every field group by default
+    (``core,io,scores,observations,metrics``). For a trace with many observations
+    that means pulling each observation together with its full input/output — often
+    megabytes — even when the caller only wants an overview. That payload is the
+    main cause of read timeouts on this tool.
+
+    The SDK's ``trace.get()`` has no ``fields`` parameter, but the server accepts a
+    ``fields`` query param and the Fern client forwards anything passed through
+    ``request_options.additional_query_parameters``. So we scope the request:
+    drop the ``observations`` field group unless observations were explicitly asked
+    for, which skips the expensive per-observation IO entirely. We also raise the
+    per-request read timeout for the heavy ``include_observations=True`` case.
+
+    Falls back to a plain ``get()`` for older SDKs that do not accept
+    ``request_options`` (or ``additional_query_parameters``).
     """
     if not hasattr(langfuse_client, "api") or not hasattr(langfuse_client.api, "trace"):
         raise RuntimeError("Unsupported Langfuse client: no trace getter available")
 
-    return langfuse_client.api.trace.get(trace_id=trace_id)
+    # Note: the endpoint has no "observations without IO" mode — including the
+    # observations group always brings their full IO — so we toggle the whole group.
+    fields = "core,io,scores,observations,metrics" if include_observations else "core,io,scores,metrics"
+    request_options = {
+        "additional_query_parameters": {"fields": fields},
+        "timeout_in_seconds": TRACE_GET_TIMEOUT_SECONDS,
+    }
+    try:
+        return langfuse_client.api.trace.get(trace_id=trace_id, request_options=request_options)
+    except TypeError:
+        # Older SDK without request_options support: fall back to a plain get().
+        return langfuse_client.api.trace.get(trace_id=trace_id)
 
 
 def _list_sessions(
@@ -1576,8 +1622,10 @@ async def fetch_trace(
     include_observations: bool = Field(
         False,
         description=(
-            "If True, fetch and include the full observation objects instead of just IDs. "
-            "Use this when you need access to system prompts, model parameters, or other details stored "
+            "If True, fetch and include the full observation objects. "
+            "If False, the observations field group is dropped entirely to avoid the expensive "
+            "per-observation IO that dominates large-trace payloads. "
+            "Use True when you need access to system prompts, model parameters, or other details stored "
             "within observations. Significantly increases response time but provides complete data. "
             "Pairs well with output_mode='full_json_file' for complete dumps."
         ),
@@ -1597,8 +1645,9 @@ async def fetch_trace(
     Args:
         ctx: Context object containing lifespan context with Langfuse client
         trace_id: The ID of the trace to fetch (unique identifier string)
-        include_observations: If True, fetch and include the full observation objects instead of just IDs.
-            Use this when you need access to system prompts, model parameters, or other details stored
+        include_observations: If True, fetch and include the full observation objects. If False, the
+            observations field group is dropped entirely to avoid expensive per-observation IO.
+            Use True when you need access to system prompts, model parameters, or other details stored
             within observations. Significantly increases response time but provides complete data.
         output_mode: Controls the output format and detail level
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -213,14 +213,18 @@ class _TraceAPI:
 
         return FakePaginatedResponse(data=data, meta={"next_page": None, "total": len(data)})
 
-    def get(self, trace_id: str, **kwargs: Any) -> dict[str, Any]:
-        self.last_get_kwargs = {"trace_id": trace_id, **kwargs}
+    def get(self, trace_id: str, *, request_options: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.last_get_kwargs = {"trace_id": trace_id}
+        if request_options is not None:
+            self.last_get_kwargs["request_options"] = request_options
         trace = self._store.traces.get(trace_id)
         if not trace:
             return {}
 
-        include_observations = "fields" in kwargs and kwargs["fields"]
-        if include_observations and "observations" in kwargs["fields"]:
+        query_params = (request_options or {}).get("additional_query_parameters", {})
+        fields = query_params.get("fields", "")
+        include_observations = bool(fields)
+        if include_observations and "observations" in fields:
             obs = [self._store.observations[o_id] for o_id in trace.observations]
             return {**trace.__dict__, "observations": [ob.__dict__ for ob in obs]}
         return trace.__dict__

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -185,7 +185,24 @@ def test_fetch_trace(state):
     result = asyncio.run(fetch_trace(ctx, trace_id="trace_1", include_observations=True, output_mode="compact"))
     assert result["data"]["id"] == "trace_1"
     assert result["data"]["observations"][0]["id"] == "obs_1"
-    assert state.langfuse_client.api.trace.last_get_kwargs == {"trace_id": "trace_1"}
+    # include_observations=True scopes the request to all field groups and raises
+    # the per-request read timeout so large traces do not time out.
+    kwargs = state.langfuse_client.api.trace.last_get_kwargs
+    assert kwargs["trace_id"] == "trace_1"
+    request_options = kwargs["request_options"]
+    assert request_options["additional_query_parameters"]["fields"] == "core,io,scores,observations,metrics"
+    assert request_options["timeout_in_seconds"] == 120
+
+
+def test_fetch_trace_without_observations_scopes_fields(state):
+    """include_observations=False must drop the expensive observations field group."""
+    from langfuse_mcp.__main__ import fetch_trace
+
+    ctx = FakeContext(state)
+    asyncio.run(fetch_trace(ctx, trace_id="trace_1", include_observations=False, output_mode="compact"))
+    fields = state.langfuse_client.api.trace.last_get_kwargs["request_options"]["additional_query_parameters"]["fields"]
+    assert "observations" not in fields
+    assert fields == "core,io,scores,metrics"
 
 
 def test_fetch_observations(observation_state):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -189,8 +190,9 @@ def test_fetch_trace(state):
     # the per-request read timeout so large traces do not time out.
     kwargs = state.langfuse_client.api.trace.last_get_kwargs
     assert kwargs["trace_id"] == "trace_1"
-    assert kwargs["fields"] == "core,io,scores,observations,metrics"
-    assert kwargs["request_options"]["timeout_in_seconds"] == 120
+    request_options = kwargs["request_options"]
+    assert request_options["additional_query_parameters"]["fields"] == "core,io,scores,observations,metrics"
+    assert request_options["timeout_in_seconds"] == 120
 
 
 def test_fetch_trace_without_observations_scopes_fields(state):
@@ -199,9 +201,50 @@ def test_fetch_trace_without_observations_scopes_fields(state):
 
     ctx = FakeContext(state)
     asyncio.run(fetch_trace(ctx, trace_id="trace_1", include_observations=False, output_mode="compact"))
-    fields = state.langfuse_client.api.trace.last_get_kwargs["fields"]
+    fields = state.langfuse_client.api.trace.last_get_kwargs["request_options"]["additional_query_parameters"]["fields"]
     assert "observations" not in fields
     assert fields == "core,io,scores,metrics"
+
+
+def test_fetch_trace_falls_back_for_clients_without_request_options(tmp_path):
+    """Older trace clients without request_options still return a trace."""
+    from langfuse_mcp.__main__ import MCPState, fetch_trace
+
+    class LegacyTraceAPI:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def get(self, trace_id: str, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append({"trace_id": trace_id, **kwargs})
+            if "request_options" in kwargs:
+                raise TypeError("unexpected keyword argument 'request_options'")
+            return {"id": trace_id, "observations": ["obs_1"]}
+
+    class LegacyAPI:
+        def __init__(self) -> None:
+            self.trace = LegacyTraceAPI()
+
+    class LegacyLangfuse:
+        def __init__(self) -> None:
+            self.api = LegacyAPI()
+
+    client = LegacyLangfuse()
+    state = MCPState(langfuse_client=client, dump_dir=str(tmp_path))
+    ctx = FakeContext(state)
+
+    result = asyncio.run(fetch_trace(ctx, trace_id="trace_1", include_observations=True, output_mode="compact"))
+
+    assert result["data"]["id"] == "trace_1"
+    assert client.api.trace.calls == [
+        {
+            "trace_id": "trace_1",
+            "request_options": {
+                "additional_query_parameters": {"fields": "core,io,scores,observations,metrics"},
+                "timeout_in_seconds": 120,
+            },
+        },
+        {"trace_id": "trace_1"},
+    ]
 
 
 def test_fetch_observations(observation_state):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -189,9 +189,8 @@ def test_fetch_trace(state):
     # the per-request read timeout so large traces do not time out.
     kwargs = state.langfuse_client.api.trace.last_get_kwargs
     assert kwargs["trace_id"] == "trace_1"
-    request_options = kwargs["request_options"]
-    assert request_options["additional_query_parameters"]["fields"] == "core,io,scores,observations,metrics"
-    assert request_options["timeout_in_seconds"] == 120
+    assert kwargs["fields"] == "core,io,scores,observations,metrics"
+    assert kwargs["request_options"]["timeout_in_seconds"] == 120
 
 
 def test_fetch_trace_without_observations_scopes_fields(state):
@@ -200,7 +199,7 @@ def test_fetch_trace_without_observations_scopes_fields(state):
 
     ctx = FakeContext(state)
     asyncio.run(fetch_trace(ctx, trace_id="trace_1", include_observations=False, output_mode="compact"))
-    fields = state.langfuse_client.api.trace.last_get_kwargs["request_options"]["additional_query_parameters"]["fields"]
+    fields = state.langfuse_client.api.trace.last_get_kwargs["fields"]
     assert "observations" not in fields
     assert fields == "core,io,scores,metrics"
 


### PR DESCRIPTION
Follow-up to #63. This keeps Edison's three commits and adds one owner-side fix commit for the supported `langfuse>=3.11.2` floor.

## Summary
- pass the single-trace `fields` selector through `request_options.additional_query_parameters` instead of a native `fields=` kwarg
- keep `LANGFUSE_MCP_TRACE_TIMEOUT_SECONDS` in `request_options` so the timeout applies on the 3.11.2 SDK floor
- tighten the trace fake to match the real `trace.get(trace_id, *, request_options=None)` signature
- add fallback coverage for clients older than the supported floor
- correct the changelog wording for the SDK-floor behavior

## Verification
- focused trace tests: 3 passed
- `tests/test_tools.py`: 39 passed
- full `pytest -q`: 148 passed, 9 skipped
- `ruff check langfuse_mcp tests`
- `ruff format --check langfuse_mcp tests`
- `pyright --pythonpath /Users/avivsinai/MyProjects/langfuse-mcp/.venv/bin/python langfuse_mcp`

Peer reviewed and approved by Claude over AMQ before commit/push.

Do not merge until release/publish timing is confirmed; merging to main publishes the marketplace plugin immediately.