### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Langfuse observability - query traces, debug exceptions, analyze sessions, manage prompts via MCP tools",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-27
 ### Added
 - **Streamable HTTP transport** (`--transport streamable-http`): run a single persistent
   server instance that serves multiple MCP clients over HTTP, eliminating the need for
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-trace fetches. The `fields` selector is forwarded through SDK request options so
   it works on the supported `langfuse>=3.11.2` floor. Falls back to a plain `get()` only
   on older SDKs that do not accept `request_options`.
+
 
 ## [0.9.1] - 2026-05-06
 ### Changed

--- a/skills/langfuse/SKILL.md
+++ b/skills/langfuse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse
-version: 0.9.1
+version: 0.10.0
 description: Debug AI agents and LLM applications via Langfuse MCP. Use when investigating traces, exceptions, slow generations, sessions, prompt versions, datasets, or evaluation sets. Triggers on "langfuse", "traces", "debug AI", "find exceptions", "what went wrong", "why is it slow", "datasets", "evaluation sets".
 metadata:
   short-description: Langfuse observability via MCP


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.10.0`
- aligns skill/plugin metadata to `0.10.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.10.0`, publishes the GitHub release, then publishes to PyPI, Docker (GHCR), and the skills marketplace in the same workflow run